### PR TITLE
Fix android -h check on mac

### DIFF
--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -183,7 +183,8 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 			}
 
 			try {
-				const output = await this.childProcess.spawnFromEvent(pathToAndroid, ["-h"], "close");
+				// On mac android -h returns exit code 1. That's why we need to ignore the error.
+				const output = await this.childProcess.spawnFromEvent(pathToAndroid, ["-h"], "close", { ignoreError: true });
 				if (output) {
 					output.stdout = output.stdout || '';
 					this.androidInstalledCache = output.stdout.indexOf("android") >= 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",


### PR DESCRIPTION
When we execute `android -h` on mac the command exits with code 1. In our childProcess if a command has exit code != 0 we throw an error. It is OK to ignore the exit code for `android -h` because the command will be executed correctly and on the stdout we will have the correct output. If android is not installed there will be no data on the stdout and we will set in the sysInfo that android is not installed.