### PR TITLE
Fix getting information about adb

### DIFF
--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -160,8 +160,8 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 
 	public getAdbVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.adbVerCache, async (): Promise<string> => {
-			const output = await this.execCommand(`${await this.androidToolsInfo.getPathToAdbFromAndroidHome()} version`);
-			return output ? this.getVersionFromString(output) : null;
+			const output = await this.childProcess.spawnFromEvent(await this.androidToolsInfo.getPathToAdbFromAndroidHome(), ["version"], "close", { ignoreError: true });
+			return output && output.stdout ? this.getVersionFromString(output.stdout) : null;
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -71,6 +71,7 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 		"xcodebuild -version": childProcessResult.xCodeVersion,
 		"pod --version": childProcessResult.podVersion,
 		"pod": childProcessResult.pod,
+		'adb': childProcessResult.adbVersion,
 		'adb version': childProcessResult.adbVersion,
 		"'adb' version": childProcessResult.adbVersion, // for Mac and Linux
 		'android': childProcessResult.androidInstalled,
@@ -83,9 +84,13 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 	};
 }
 
-function getResultFromChildProcess(childProcessResultDescription: IChildProcessResultDescription, command: string): any {
+function getResultFromChildProcess(childProcessResultDescription: IChildProcessResultDescription, command: string, options?: ISpawnFromEventOptions): any {
 	if (childProcessResultDescription.shouldThrowError) {
-		throw new Error(`This one throws error. (${command})`);
+		if (options && options.ignoreError) {
+			return null;
+		} else {
+			throw new Error(`This one throws error. (${command})`);
+		}
 	}
 
 	return childProcessResultDescription.result;
@@ -111,8 +116,8 @@ function mockSysInfo(childProcessResult: IChildProcessResults, hostInfoOptions?:
 		exec: async (command: string) => {
 			return getResultFromChildProcess(childProcessResultDictionary[command], command);
 		},
-		spawnFromEvent: async (command: string, args: string[], event: string) => {
-			return getResultFromChildProcess(childProcessResultDictionary[command], command);
+		spawnFromEvent: async (command: string, args: string[], event: string, options: ISpawnFromEventOptions) => {
+			return getResultFromChildProcess(childProcessResultDictionary[command], command, options);
 		},
 		execFile: async () => {
 			return undefined;


### PR DESCRIPTION
When path to ANDROID_HOME contains spaces, we do not get the path to adb correctly and we return error that adb is not installed.
Fix this by using child_process.spawn which handles spaces.
Fix incorrect tests which did not consider the `ignoreError` option of spawnFromEvent method.