### PR TITLE
Fix getting adb version when ANDROID_HOME is not set 

### DIFF
--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -160,7 +160,12 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 
 	public getAdbVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.adbVerCache, async (): Promise<string> => {
-			const output = await this.childProcess.spawnFromEvent(await this.androidToolsInfo.getPathToAdbFromAndroidHome(), ["version"], "close", { ignoreError: true });
+			let output: IProcessInfo = null;
+			const pathToAdbFromAndroidHome = await this.androidToolsInfo.getPathToAdbFromAndroidHome();
+			if (pathToAdbFromAndroidHome) {
+				output = await this.childProcess.spawnFromEvent(pathToAdbFromAndroidHome, ["version"], "close", { ignoreError: true });
+			}
+
 			return output && output.stdout ? this.getVersionFromString(output.stdout) : null;
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",


### PR DESCRIPTION
In case ANDROID_HOME is not set, trying to get adb version leads to error. Fix this by checking the value of pathToAdbFromAndroidHome. In case it is not set, return null.