### PR TITLE
Add getting version of nativescript-cloud library

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ Library that helps identifying if the environment can be used for development of
 
 		// node stuff
 		/**
-		 * node.js version, returned by `process.version`.
+		 * node.js version, returned by node -v.
 		 * @type {string}
 		 */
 		nodeVer: string;
 
-		/** 
+		/**
 		 * npm version, returned by `npm -v`.
 		 * @type {string}
 		 */
@@ -404,6 +404,12 @@ Library that helps identifying if the environment can be used for development of
 		 * @type {string}
 		 */
 		nativeScriptCliVersion: string;
+
+		/**
+		 * The version of `nativescript-cloud` library, as returned by `tns cloud lib version`.
+		 * @type {string}
+		 */
+		nativeScriptCloudVersion: string;
 
 		/**
 		 * Information about xcproj.

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -26,6 +26,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	private javaCompilerVerCache: string;
 	private xCodeVerCache: string;
 	private npmVerCache: string;
+	private nodeVerCache: string;
 	private nodeGypVerCache: string;
 	private xCodeprojGemLocationCache: string;
 	private iTunesInstalledCache: boolean;
@@ -39,6 +40,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	private sysInfoCache: NativeScriptDoctor.ISysInfoData;
 	private isCocoaPodsWorkingCorrectlyCache: boolean;
 	private nativeScriptCliVersionCache: string;
+	private nativeScriptCloudVersionCache: string;
 	private xcprojInfoCache: NativeScriptDoctor.IXcprojInfo;
 	private isCocoaPodsUpdateRequiredCache: boolean;
 	private shouldCache: boolean = true;
@@ -91,7 +93,15 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	}
 
 	public async getNodeVersion(): Promise<string> {
-		return this.getVersionFromString(process.version);
+		return this.getValueForProperty(() => this.nodeVerCache, async (): Promise<string> => {
+			const output = await this.execCommand("node -v");
+			if (output) {
+				const version = this.getVersionFromString(output);
+				return version || output;
+			}
+
+			return null;
+		});
 	}
 
 	public getNpmVersion(): Promise<string> {
@@ -243,7 +253,10 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 			result.gitVer = await this.getGitVersion();
 			result.gradleVer = await this.getGradleVersion();
 			result.isCocoaPodsWorkingCorrectly = await this.isCocoaPodsWorkingCorrectly();
+
 			result.nativeScriptCliVersion = await this.getNativeScriptCliVersion();
+			result.nativeScriptCloudVersion = await this.getNativeScriptCloudVersion();
+
 			result.isCocoaPodsUpdateRequired = await this.isCocoaPodsUpdateRequired();
 			result.isAndroidSdkConfiguredCorrectly = await this.isAndroidSdkConfiguredCorrectly();
 
@@ -281,6 +294,13 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	public getNativeScriptCliVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.nativeScriptCliVersionCache, async (): Promise<string> => {
 			const output = await this.execCommand("tns --version");
+			return output ? output.trim() : output;
+		});
+	}
+
+	public getNativeScriptCloudVersion(): Promise<string> {
+		return this.getValueForProperty(() => this.nativeScriptCloudVersionCache, async (): Promise<string> => {
+			const output = await this.execCommand("tns cloud lib version");
 			return output ? output.trim() : output;
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -16,6 +16,7 @@ interface IChildProcessResultDescription {
 interface IChildProcessResults {
 	uname: IChildProcessResultDescription;
 	npmV: IChildProcessResultDescription;
+	nodeV: IChildProcessResultDescription;
 	javaVersion: IChildProcessResultDescription;
 	javacVersion: IChildProcessResultDescription;
 	nodeGypVersion: IChildProcessResultDescription;
@@ -65,6 +66,7 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 	return {
 		"uname -a": childProcessResult.uname,
 		"npm -v": childProcessResult.npmV,
+		"node -v": childProcessResult.nodeV,
 		"java": childProcessResult.javaVersion,
 		'"javac" -version': childProcessResult.javacVersion,
 		"node-gyp -v": childProcessResult.nodeGypVersion,
@@ -207,6 +209,7 @@ describe("SysInfo unit tests", () => {
 			childProcessResult = {
 				uname: { result: setStdOut("name") },
 				npmV: { result: setStdOut("2.14.1") },
+				nodeV: { result: setStdOut("v6.0.0") },
 				javaVersion: { result: setStdErr('java version "1.8.0_60"') },
 				javacVersion: { result: setStdErr("javac 1.8.0_60") },
 				nodeGypVersion: { result: setStdOut("2.0.0") },
@@ -233,6 +236,7 @@ describe("SysInfo unit tests", () => {
 		describe("returns correct results when everything is installed", () => {
 			let assertCommonValues = (result: NativeScriptDoctor.ISysInfoData) => {
 				assert.deepEqual(result.npmVer, childProcessResult.npmV.result.stdout);
+				assert.deepEqual(result.nodeVer, "6.0.0");
 				assert.deepEqual(result.javaVer, "1.8.0");
 				assert.deepEqual(result.javacVersion, "1.8.0_60");
 				assert.deepEqual(result.nodeGypVer, childProcessResult.nodeGypVersion.result.stdout);
@@ -308,6 +312,7 @@ describe("SysInfo unit tests", () => {
 				childProcessResult = {
 					uname: { shouldThrowError: true },
 					npmV: { shouldThrowError: true },
+					nodeV: { shouldThrowError: true },
 					javaVersion: { shouldThrowError: true },
 					javacVersion: { shouldThrowError: true },
 					nodeGypVersion: { shouldThrowError: true },

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -100,6 +100,12 @@ declare module NativeScriptDoctor {
 		getNativeScriptCliVersion(): Promise<string>;
 
 		/**
+		 * Returns the version of the installed `nativescript-cloud` version.
+		 * @return {Promise<string>} Returns the version of the installed `nativescript-cloud` version.
+		 */
+		getNativeScriptCloudVersion(): Promise<string>;
+
+		/**
 		 * Checks if xcproj is required to build projects and if it is installed.
 		 * @return {Promise<IXcprojInfo>} Returns the collected information aboud xcproj.
 		 */
@@ -177,12 +183,12 @@ declare module NativeScriptDoctor {
 
 		// node stuff
 		/**
-		 * node.js version, returned by `process.version`.
+		 * node.js version, returned by node -v.
 		 * @type {string}
 		 */
 		nodeVer: string;
 
-		/** 
+		/**
 		 * npm version, returned by `npm -v`.
 		 * @type {string}
 		 */
@@ -278,6 +284,12 @@ declare module NativeScriptDoctor {
 		 * @type {string}
 		 */
 		nativeScriptCliVersion: string;
+
+		/**
+		 * The version of `nativescript-cloud` library, as returned by `tns cloud lib version`.
+		 * @type {string}
+		 */
+		nativeScriptCloudVersion: string;
 
 		/**
 		 * Information about xcproj.


### PR DESCRIPTION
Add command to get the version of `nativescript-cloud` library.
Fix getting the version of globally installed Node.js - we've been incorrectly using `process.version` instead of spawning `node -v`.