### PR TITLE
Fix getting the version of nativescript-cloud when it is not installed

### DIFF
--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -301,7 +301,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	public getNativeScriptCloudVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.nativeScriptCloudVersionCache, async (): Promise<string> => {
 			const output = await this.execCommand("tns cloud lib version");
-			return output ? output.trim() : output;
+			return output ? this.getVersionFromString(output.trim()) : output;
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",


### PR DESCRIPTION
In case `nativescript-cloud` lib is not installed, the spawned tns command fails and prints the result to the stdout.
So add parsing of the result and use it only when the stdout is valid version.