### PR TITLE
Fix getting CLI version

### DIFF
--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -68,7 +68,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	public getJavaCompilerVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.javaCompilerVerCache, async (): Promise<string> => {
 			const javaCompileExecutableName = "javac";
-			const javaHome = process.env.JAVA_HOME;
+			const javaHome = process.env["JAVA_HOME"];
 			const pathToJavaCompilerExecutable = javaHome ? path.join(javaHome, "bin", javaCompileExecutableName) : javaCompileExecutableName;
 			try {
 				const output = await this.childProcess.exec(`"${pathToJavaCompilerExecutable}" -version`);
@@ -135,7 +135,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 			let mobileDeviceDir: string;
 
 			if (this.hostInfo.isWindows) {
-				const commonProgramFiles = this.hostInfo.isWindows64 ? process.env["CommonProgramFiles(x86)"] : process.env.CommonProgramFiles;
+				const commonProgramFiles = this.hostInfo.isWindows64 ? process.env["CommonProgramFiles(x86)"] : process.env["CommonProgramFiles"];
 				coreFoundationDir = path.join(commonProgramFiles, "Apple", "Apple Application Support");
 				mobileDeviceDir = path.join(commonProgramFiles, "Apple", "Mobile Device Support");
 			} else if (this.hostInfo.isDarwin) {

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -298,7 +298,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	public getNativeScriptCliVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.nativeScriptCliVersionCache, async (): Promise<string> => {
 			const output = await this.execCommand("tns --version");
-			return output ? output.trim() : output;
+			return output ? this.getVersionFromString(output.trim()) : output;
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -153,7 +153,7 @@ describe("SysInfo unit tests", () => {
 
 	beforeEach(() => {
 		// We need to mock this because on Mac the tests in which the platform is mocked to Windows in the process there will be no CommonProgramFiles.
-		process.env.CommonProgramFiles = process.env.CommonProgramFiles || "mocked on mac";
+		process.env["CommonProgramFiles"] = process.env["CommonProgramFiles"] || "mocked on mac";
 		process.env["CommonProgramFiles(x86)"] = process.env["CommonProgramFiles(x86)"] || "mocked on mac";
 	});
 

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -126,7 +126,7 @@ function mockSysInfo(childProcessResult: IChildProcessResults, hostInfoOptions?:
 		spawnFromEvent: async (command: string, args: string[], event: string, options: ISpawnFromEventOptions) => {
 			return getResultFromChildProcess(childProcessResultDictionary[command], command, options);
 		},
-		execFile: async () => {
+		execFile: async (): Promise<any> => {
 			return undefined;
 		}
 	};
@@ -319,6 +319,29 @@ describe("SysInfo unit tests", () => {
 				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" });
 				let result = await sysInfo.getSysInfo();
 				assert.deepEqual(result.cocoaPodsVer, "0.38.2");
+			});
+		});
+
+		describe("nativeScriptCliVersion", () => {
+			it("is null when tns is not installed", async () => {
+				childProcessResult.nativeScriptCliVersion = { shouldThrowError: true };
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" });
+				let result = await sysInfo.getSysInfo();
+				assert.deepEqual(result.nativeScriptCliVersion, null);
+			});
+
+			it("is correct when the version is the only row in `tns --version` output", async () => {
+				childProcessResult.nativeScriptCliVersion = { result: setStdOut("3.0.0") };
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" });
+				let result = await sysInfo.getSysInfo();
+				assert.deepEqual(result.nativeScriptCliVersion, "3.0.0");
+			});
+
+			it("is correct when there are warnings in the `tns --version` output", async () => {
+				childProcessResult.nativeScriptCliVersion = { result: setStdOut("Some warning due to invalid extensions\\n3.0.0") };
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" });
+				let result = await sysInfo.getSysInfo();
+				assert.deepEqual(result.nativeScriptCliVersion, "3.0.0");
 			});
 		});
 


### PR DESCRIPTION
### Fix getting CLI version
In case CLI prints other things (like warnings from loading extensions) to its stdout, the `nativescript-doctor` returns incorrect version for CLI.
Fix this by getting only the version from stdout.
Add unit tests for this scenario.

### Fix transpilation
`@types/temp` depends on `"@types/node": "*"`, so a new version of the `node.d.ts` is installed. This breaks our code. Fix the code, but we'll have to figure it out how to make sure it won't happen again.