### PR TITLE
Fix some failures

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 
 export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 	private static ANDROID_TARGET_PREFIX = "android";
-	private static SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21", "android-22", "android-23", "android-24", "android-25"];
+	private static SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21", "android-22", "android-23", "android-24", "android-25", "android-26"];
 	private static MIN_REQUIRED_COMPILE_TARGET = 22;
 	private static REQUIRED_BUILD_TOOLS_RANGE_PREFIX = ">=23";
 	private static VERSION_REGEX = /((\d+\.){2}\d+)/;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -22,6 +22,15 @@ export class Helpers {
 		return this.hostInfo.isWindows ? this.cmdQuote(value) : this.bashQuote(value);
 	}
 
+	public appendZeroesToVersion(version: string, requiredVersionLength: number): string {
+		const zeroesToAppend = requiredVersionLength - version.split(".").length;
+		for (let index = 0; index < zeroesToAppend; index++) {
+			version += ".0";
+		}
+
+		return version;
+	}
+
 	private bashQuote(s: string): string {
 		if (s[0] === "'" && s[s.length - 1] === "'") {
 			return s;

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -313,7 +313,10 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	public getXcprojInfo(): Promise<NativeScriptDoctor.IXcprojInfo> {
 		return this.getValueForProperty(() => this.xcprojInfoCache, async (): Promise<NativeScriptDoctor.IXcprojInfo> => {
 			const cocoaPodsVersion = await this.getCocoaPodsVersion();
-			const xcodeVersion = await this.getXcodeVersion();
+			let xcodeVersion = await this.getXcodeVersion();
+			if (xcodeVersion) {
+				xcodeVersion = this.helpers.appendZeroesToVersion(xcodeVersion, 3);
+			}
 
 			// CocoaPods with version lower than 1.0.0 don't support Xcode 7.3 yet
 			// https://github.com/CocoaPods/CocoaPods/issues/2530#issuecomment-210470123

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "typescript": "2.0.3"
   },
   "dependencies": {
-    "bluebird": "3.4.6",
     "osenv": "0.1.3",
     "semver": "5.3.0",
     "temp": "0.8.3",

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -333,6 +333,16 @@ describe("SysInfo unit tests", () => {
 			});
 		});
 
+		describe("getXcprojInfo", () => {
+			it("does not fail when cocoapods version is below 1.0.0 and Xcode version contains only two digits", async () => {
+				childProcessResult.podVersion = { result: setStdOut("0.39.0") };
+				childProcessResult.xCodeVersion = { result: setStdOut("Xcode 8.3") };
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion });
+				const result = await sysInfo.getXcprojInfo();
+				assert.deepEqual(result, { shouldUseXcproj: true, xcprojAvailable: false });
+			});
+		});
+
 		const testData: ICLIOutputVersionTestCase[] = [
 			{
 				testedProperty: "nativeScriptCliVersion",


### PR DESCRIPTION
### Allow using version 26 of Android SDK
It is already used in NativeScript CLI.

### Fix exception when checking if xcproj is required
In case Cocoapods version is below 1.0.0 and Xcode version contains only two digits, we fail as semver cannot work with versions with two digits.
Append zero to the version, to make it correct semver.

### Remove bluebird dependency as it is not used anywher
