### PR TITLE
Remove getting cloud lib version

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,12 +415,6 @@ Library that helps identifying if the environment can be used for development of
 		nativeScriptCliVersion: string;
 
 		/**
-		 * The version of `nativescript-cloud` library, as returned by `tns cloud lib version`.
-		 * @type {string}
-		 */
-		nativeScriptCloudVersion: string;
-
-		/**
 		 * Information about xcproj.
 		 * @type {string}
 		 */

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -41,7 +41,6 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	private sysInfoCache: NativeScriptDoctor.ISysInfoData;
 	private isCocoaPodsWorkingCorrectlyCache: boolean;
 	private nativeScriptCliVersionCache: string;
-	private nativeScriptCloudVersionCache: string;
 	private xcprojInfoCache: NativeScriptDoctor.IXcprojInfo;
 	private isCocoaPodsUpdateRequiredCache: boolean;
 	private shouldCache: boolean = true;
@@ -260,7 +259,6 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 			result.isCocoaPodsWorkingCorrectly = await this.isCocoaPodsWorkingCorrectly();
 
 			result.nativeScriptCliVersion = await this.getNativeScriptCliVersion();
-			result.nativeScriptCloudVersion = await this.getNativeScriptCloudVersion();
 
 			result.isCocoaPodsUpdateRequired = await this.isCocoaPodsUpdateRequired();
 			result.isAndroidSdkConfiguredCorrectly = await this.isAndroidSdkConfiguredCorrectly();
@@ -299,13 +297,6 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	public getNativeScriptCliVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.nativeScriptCliVersionCache, async (): Promise<string> => {
 			const output = await this.execCommand("tns --version");
-			return output ? this.getVersionFromCLIOutput(output.trim()) : output;
-		});
-	}
-
-	public getNativeScriptCloudVersion(): Promise<string> {
-		return this.getValueForProperty(() => this.nativeScriptCloudVersionCache, async (): Promise<string> => {
-			const output = await this.execCommand("tns cloud lib version");
 			return output ? this.getVersionFromCLIOutput(output.trim()) : output;
 		});
 	}

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -37,7 +37,6 @@ interface IChildProcessResults {
 	podVersion: IChildProcessResultDescription;
 	pod: IChildProcessResultDescription;
 	nativeScriptCliVersion: IChildProcessResultDescription;
-	nativeScriptCloudVersion: IChildProcessResultDescription;
 	git: IChildProcessResultDescription;
 }
 
@@ -94,7 +93,6 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 		'"C:\\Program Files/Git/cmd/git.exe" --version': childProcessResult.gitVersion, // When running Windows test on the Non-Windows platform
 		"gradle -v": childProcessResult.gradleVersion,
 		"tns --version": childProcessResult.nativeScriptCliVersion,
-		"tns cloud lib version": childProcessResult.nativeScriptCloudVersion,
 		"emulator": { shouldThrowError: false },
 		"which git": childProcessResult.git
 	};
@@ -240,7 +238,6 @@ describe("SysInfo unit tests", () => {
 				podVersion: { result: setStdOut("0.38.2") },
 				pod: { result: setStdOut("success") },
 				nativeScriptCliVersion: { result: setStdOut("2.5.0") },
-				nativeScriptCloudVersion: { result: setStdOut("0.1.0") },
 				git: { result: setStdOut("git") }
 			};
 
@@ -347,10 +344,6 @@ describe("SysInfo unit tests", () => {
 			{
 				testedProperty: "nativeScriptCliVersion",
 				method: (currentSysInfo: SysInfo) => currentSysInfo.getNativeScriptCliVersion()
-			},
-			{
-				testedProperty: "nativeScriptCloudVersion",
-				method: (currentSysInfo: SysInfo) => currentSysInfo.getNativeScriptCloudVersion()
 			}];
 
 		testData.forEach((testCase) => {
@@ -419,7 +412,6 @@ ${expectedCliVersion}`;
 					podVersion: { shouldThrowError: true },
 					pod: { shouldThrowError: true },
 					nativeScriptCliVersion: { shouldThrowError: true },
-					nativeScriptCloudVersion: { shouldThrowError: true },
 					git: { shouldThrowError: false }
 				};
 				androidToolsInfo.validateAndroidHomeEnvVariable = (): any[] => [1];

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -106,12 +106,6 @@ declare module NativeScriptDoctor {
 		getNativeScriptCliVersion(): Promise<string>;
 
 		/**
-		 * Returns the version of the installed `nativescript-cloud` version.
-		 * @return {Promise<string>} Returns the version of the installed `nativescript-cloud` version.
-		 */
-		getNativeScriptCloudVersion(): Promise<string>;
-
-		/**
 		 * Checks if xcproj is required to build projects and if it is installed.
 		 * @return {Promise<IXcprojInfo>} Returns the collected information aboud xcproj.
 		 */
@@ -290,12 +284,6 @@ declare module NativeScriptDoctor {
 		 * @type {string}
 		 */
 		nativeScriptCliVersion: string;
-
-		/**
-		 * The version of `nativescript-cloud` library, as returned by `tns cloud lib version`.
-		 * @type {string}
-		 */
-		nativeScriptCloudVersion: string;
 
 		/**
 		 * Information about xcproj.


### PR DESCRIPTION
Remove getting cloud lib version through spawning command as this is no longer required. CLI has API to get the installed extensions, so it should be used instead.