### PR TITLE
Add check for JAVA 9 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
+- '6'
 git:
   submodules: false
 before_script:

--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ Library that helps identifying if the environment can be used for development of
 		// The default value is true. If set to false the result of each check for each element
 		// of the sys info will not be cached.
 		setShouldCacheSysInfo(false);
-		const javaVersion = await sysInfo.getJavaVersion();
-		console.log("java: ", javaVersion);
 
 		const javacVersion = await sysInfo.getJavaCompilerVersion();
 		console.log("javac: ", javacVersion);
@@ -150,12 +148,6 @@ Library that helps identifying if the environment can be used for development of
 	 * Describes methods which helps collecting system information.
 	 */
 	interface ISysInfo {
-		/**
-		 * Returns the currently installed Java version.
-		 * @return {Promise<string>} The currently installed Java version.
-		 */
-		getJavaVersion(): Promise<string>;
-
 		/**
 		 * Returns the currently installed Java compiler version.
 		 * @return {Promise<string>} The currently installed Java compiler version.
@@ -336,12 +328,6 @@ Library that helps identifying if the environment can be used for development of
 		nodeGypVer: string;
 
 		// dependencies
-		/**
-		 * Version of java, as returned by `java -version`.
-		 * @type {string}
-		 */
-		javaVer: string;
-
 		/**
 		 * Xcode version string as returned by `xcodebuild -version`. Valid only on Mac.
 		 * @type {string}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,4 +2,9 @@ export class Constants {
 	public static ANDROID_PLATFORM_NAME = "Android";
 	public static IOS_PLATFORM_NAME = "iOS";
 	public static SUPPORTED_PLATFORMS = [Constants.ANDROID_PLATFORM_NAME, Constants.IOS_PLATFORM_NAME];
+	public static SYSTEM_REQUIREMENTS_LINKS: IDictionary<string> = {
+		"win32": "http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-win.html#system-requirements",
+		"linux": "http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-linux.html#system-requirements",
+		"darwin": "http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-os-x.html#system-requirements",
+	};
 }

--- a/lib/doctor.ts
+++ b/lib/doctor.ts
@@ -131,14 +131,13 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 			});
 		}
 
-		if (!sysInfoData.javaVer) {
+		if (!sysInfoData.javacVersion) {
 			result.push({
 				warning: "WARNING: The Java Development Kit (JDK) is not installed or is not configured properly.",
 				additionalInformation: "You will not be able to work with the Android SDK and you might not be able" + EOL
 				+ "to perform some Android-related operations. To ensure that you can develop and" + EOL
 				+ "test your apps for Android, verify that you have installed the JDK as" + EOL
-				+ "described in http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html (for JDK 8)" + EOL
-				+ "or http://docs.oracle.com/javase/7/docs/webnotes/install/ (for JDK 7)." + EOL,
+				+ "described in http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html (for JDK 8)." + EOL,
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			});
 		}

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -22,10 +22,18 @@ export class Helpers {
 		return this.hostInfo.isWindows ? this.cmdQuote(value) : this.bashQuote(value);
 	}
 
+	/**
+	 * Appends zeroes to a version string until it reaches a specified length.
+	 * @param {string} version The version on which to append zeroes.
+	 * @param {number} requiredVersionLength The required length of the version string.
+	 * @returns {string} Appended version string. In case input is null, undefined or empty string, it is returned immediately without appending anything.
+	 */
 	public appendZeroesToVersion(version: string, requiredVersionLength: number): string {
-		const zeroesToAppend = requiredVersionLength - version.split(".").length;
-		for (let index = 0; index < zeroesToAppend; index++) {
-			version += ".0";
+		if (version) {
+			const zeroesToAppend = requiredVersionLength - version.split(".").length;
+			for (let index = 0; index < zeroesToAppend; index++) {
+				version += ".0";
+			}
 		}
 
 		return version;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,7 +15,7 @@ const winReg = new WinReg();
 const hostInfo = new HostInfo(winReg);
 const fileSystem = new FileSystem();
 const helpers = new Helpers(hostInfo);
-const androidToolsInfo = new AndroidToolsInfo(childProcess, fileSystem, hostInfo);
+const androidToolsInfo = new AndroidToolsInfo(childProcess, fileSystem, hostInfo, helpers);
 
 const sysInfo: NativeScriptDoctor.ISysInfo = new SysInfo(childProcess, fileSystem, helpers, hostInfo, winReg, androidToolsInfo);
 

--- a/lib/local-build-requirements/android-local-build-requirements.ts
+++ b/lib/local-build-requirements/android-local-build-requirements.ts
@@ -6,7 +6,6 @@ export class AndroidLocalBuildRequirements {
 		const androidToolsInfo = await this.androidToolsInfo.validateInfo();
 		if (androidToolsInfo.length ||
 			!await this.sysInfo.getJavaCompilerVersion() ||
-			!await this.sysInfo.getJavaVersion() ||
 			!await this.sysInfo.getAdbVersion()) {
 			return false;
 		}

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   },
   "homepage": "https://github.com/NativeScript/nativescript-doctor#readme",
   "devDependencies": {
+    "@types/chai": "4.1.0",
     "@types/mocha": "2.2.32",
     "@types/semver": "5.3.30",
     "@types/temp": "0.8.29",
     "@types/winreg": "1.2.30",
+    "chai": "4.1.2",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-watch": "1.0.0",

--- a/test/android-tools-info.ts
+++ b/test/android-tools-info.ts
@@ -1,0 +1,77 @@
+import { AndroidToolsInfo } from '../lib/android-tools-info';
+import { EOL } from 'os';
+import { assert } from "chai";
+import { ChildProcess } from '../lib/wrappers/child-process';
+import { FileSystem } from '../lib/wrappers/file-system';
+import { HostInfo } from '../lib/host-info';
+import { Helpers } from '../lib/helpers';
+import { Constants } from '../lib/constants';
+
+interface ITestData {
+	javacVersion: string;
+	warnings?: string[];
+}
+
+describe("androidToolsInfo", () => {
+	const additionalInformation = "You will not be able to build your projects for Android." + EOL
+	+ "To be able to build for Android, verify that you have installed The Java Development Kit (JDK) and configured it according to system requirements as" + EOL +
+	" described in " + Constants.SYSTEM_REQUIREMENTS_LINKS[process.platform];
+
+	const getAndroidToolsInfo = (): AndroidToolsInfo => {
+		const childProcess: ChildProcess = <any>{};
+		const fs: FileSystem = <any>{};
+		const hostInfo: HostInfo = <any>{};
+		const helpers: Helpers = new Helpers(<any>{});
+		return new AndroidToolsInfo(childProcess, fs, hostInfo, helpers);
+	};
+
+	describe("validateJavacVersion", () => {
+		const testData: ITestData[] = [
+			{
+				javacVersion: "1.8.0"
+			},
+			{
+				javacVersion: "1.8.0_152"
+			},
+			{
+				javacVersion: "9",
+				warnings: ["Javac version 9 is not supported. You have to install version 1.8.0."]
+			},
+			{
+				javacVersion: "9.0.1",
+				warnings: ["Javac version 9.0.1 is not supported. You have to install version 1.8.0."]
+			},
+			{
+				javacVersion: "1.7.0",
+				warnings: ["Javac version 1.7.0 is not supported. You have to install at least 1.8.0."]
+			},
+			{
+				javacVersion: "1.7.0_132",
+				warnings: ["Javac version 1.7.0_132 is not supported. You have to install at least 1.8.0."]
+			},
+			{
+				javacVersion: null,
+				warnings: ["Error executing command 'javac'. Make sure you have installed The Java Development Kit (JDK) and set JAVA_HOME environment variable."]
+			}
+		];
+
+		testData.forEach(({ javacVersion, warnings }) => {
+			it(`returns correct result when version is ${javacVersion}`, () => {
+				const androidToolsInfo = getAndroidToolsInfo();
+				const actualWarnings = androidToolsInfo.validateJavacVersion(javacVersion);
+				let expectedWarnings: NativeScriptDoctor.IWarning[] = [];
+				if (warnings && warnings.length) {
+					expectedWarnings = warnings.map(warning => {
+						return {
+							platforms: [Constants.ANDROID_PLATFORM_NAME],
+							warning,
+							additionalInformation
+						};
+					});
+				}
+
+				assert.deepEqual(actualWarnings, expectedWarnings);
+			});
+		});
+	});
+});

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -25,7 +25,6 @@ interface IChildProcessResults {
 	uname: IChildProcessResultDescription;
 	npmV: IChildProcessResultDescription;
 	nodeV: IChildProcessResultDescription;
-	javaVersion: IChildProcessResultDescription;
 	javacVersion: IChildProcessResultDescription;
 	nodeGypVersion: IChildProcessResultDescription;
 	xCodeVersion: IChildProcessResultDescription;
@@ -76,7 +75,6 @@ function createChildProcessResults(childProcessResult: IChildProcessResults): ID
 		"uname -a": childProcessResult.uname,
 		"npm -v": childProcessResult.npmV,
 		"node -v": childProcessResult.nodeV,
-		"java": childProcessResult.javaVersion,
 		'"javac" -version': childProcessResult.javacVersion,
 		"node-gyp -v": childProcessResult.nodeGypVersion,
 		"xcodebuild -version": childProcessResult.xCodeVersion,
@@ -188,11 +186,6 @@ describe("SysInfo unit tests", () => {
 			sysInfo = new SysInfo(childProcess, null, helpers, null, null, androidToolsInfo);
 		});
 
-		it("java version.", async () => {
-			await sysInfo.getJavaVersion();
-			assert.deepEqual(spawnFromEventCommand, "java -version");
-		});
-
 		it("java compiler version when there is JAVA_HOME.", async () => {
 			const originalJavaHome = process.env[JavaHomeName];
 			process.env[JavaHomeName] = "mock";
@@ -226,7 +219,6 @@ describe("SysInfo unit tests", () => {
 				uname: { result: setStdOut("name") },
 				npmV: { result: setStdOut("2.14.1") },
 				nodeV: { result: setStdOut("v6.0.0") },
-				javaVersion: { result: setStdErr('java version "1.8.0_60"') },
 				javacVersion: { result: setStdErr("javac 1.8.0_60") },
 				nodeGypVersion: { result: setStdOut("2.0.0") },
 				xCodeVersion: { result: setStdOut("Xcode 6.4.0") },
@@ -254,7 +246,6 @@ describe("SysInfo unit tests", () => {
 			let assertCommonValues = (result: NativeScriptDoctor.ISysInfoData) => {
 				assert.deepEqual(result.npmVer, childProcessResult.npmV.result.stdout);
 				assert.deepEqual(result.nodeVer, "6.0.0");
-				assert.deepEqual(result.javaVer, "1.8.0");
 				assert.deepEqual(result.javacVersion, "1.8.0_60");
 				assert.deepEqual(result.nodeGypVer, childProcessResult.nodeGypVersion.result.stdout);
 				assert.deepEqual(result.adbVer, "1.0.32");
@@ -400,7 +391,6 @@ ${expectedCliVersion}`;
 					uname: { shouldThrowError: true },
 					npmV: { shouldThrowError: true },
 					nodeV: { shouldThrowError: true },
-					javaVersion: { shouldThrowError: true },
 					javacVersion: { shouldThrowError: true },
 					nodeGypVersion: { shouldThrowError: true },
 					xCodeVersion: { shouldThrowError: true },
@@ -421,7 +411,6 @@ ${expectedCliVersion}`;
 				let assertAllValuesAreNull = async () => {
 					const result = await sysInfo.getSysInfo();
 					assert.deepEqual(result.npmVer, null);
-					assert.deepEqual(result.javaVer, null);
 					assert.deepEqual(result.javacVersion, null);
 					assert.deepEqual(result.nodeGypVer, null);
 					assert.deepEqual(result.xcodeVer, null);

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -4,12 +4,6 @@ declare module NativeScriptDoctor {
 	 */
 	interface ISysInfo {
 		/**
-		 * Returns the currently installed Java version.
-		 * @return {Promise<string>} The currently installed Java version.
-		 */
-		getJavaVersion(): Promise<string>;
-
-		/**
 		 * Returns the currently installed Java compiler version.
 		 * @return {Promise<string>} The currently installed Java compiler version.
 		 */
@@ -207,12 +201,6 @@ declare module NativeScriptDoctor {
 		nodeGypVer: string;
 
 		// dependencies
-		/**
-		 * Version of java, as returned by `java -version`.
-		 * @type {string}
-		 */
-		javaVer: string;
-
 		/**
 		 * Xcode version string as returned by `xcodebuild -version`. Valid only on Mac.
 		 * @type {string}


### PR DESCRIPTION
* Add check for JAVA 9

Currently Gradle cannot work with JAVA 9, so detect if it has been used and return correct warning.

Fix detection of Javac version

The command `javac -version` prints result to stderr when JAVA 8 is used and to stdout when JAVA 9 is used. Current check uses the stderr output, so when JAVA 9 is installed it fails to detect the correct version.
In order to support both JAVA 8 and JAVA 9, capture both stdout and stderr and get the version from there.
Also remove unneeded check for Java version - we care about JAVA Compiler, which is included in JDK.

* Handle case when Javac version is a single number (9 for example)

In some cases javac version is a single number, for example 9. In this case our validation fails to detect the correct version and to check if we support this version.
In order to resolve this issue, use the `appendZeroesToVersion` method in order to make the version semver valid.


Update travis to use Node.js 6, so we can use ES6 features.