### PR TITLE
Get sysInfos based on specified platform

### DIFF
--- a/lib/doctor.ts
+++ b/lib/doctor.ts
@@ -32,28 +32,12 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		let result: NativeScriptDoctor.IInfo[] = [];
 		const sysInfoData = await this.sysInfo.getSysInfo(config);
 
-		result = result.concat(
-			this.processSysInfoItem({
-				item: sysInfoData.gitVer,
-				infoMessage: "Git is installed and is configured properly.",
-				warningMessage: "Git is not installed or not configured properly.",
-				additionalInformation: "You will not be able to create and work with Screen Builder projects." + EOL
-					+ "To be able to work with Screen Builder projects, download and install Git as described" + EOL
-					+ "in https://git-scm.com/downloads and add the git executable to your PATH.",
-				platforms: Constants.SUPPORTED_PLATFORMS
-			})
-		);
-
-		if (config && config.platform === Constants.ANDROID_PLATFORM_NAME) {
+		if (!config || !config.platform || config.platform === Constants.ANDROID_PLATFORM_NAME) {
 			result = result.concat(this.getAndroidInfos(sysInfoData));
 		}
 
-		if (config && config.platform === Constants.IOS_PLATFORM_NAME) {
+		if (!config || !config.platform || config.platform === Constants.IOS_PLATFORM_NAME) {
 			result = result.concat(await this.getiOSInfos(sysInfoData));
-		}
-
-		if (!config || !config.platform) {
-			result = result.concat(this.getAndroidInfos(sysInfoData), await this.getiOSInfos(sysInfoData));
 		}
 
 		if (!this.hostInfo.isDarwin) {
@@ -163,7 +147,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 					platforms: [Constants.IOS_PLATFORM_NAME]
 				})
 			);
-	
+
 			if (sysInfoData.xcodeVer && sysInfoData.cocoaPodsVer) {
 				let isCocoaPodsWorkingCorrectly = await this.sysInfo.isCocoaPodsWorkingCorrectly();
 				result = result.concat(
@@ -176,7 +160,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 					})
 				);
 			}
-	
+
 			result = result.concat(
 				this.processSysInfoItem({
 					item: !sysInfoData.cocoaPodsVer || !semver.valid(sysInfoData.cocoaPodsVer) || !semver.lt(sysInfoData.cocoaPodsVer, Doctor.MIN_SUPPORTED_POD_VERSION),

--- a/lib/doctor.ts
+++ b/lib/doctor.ts
@@ -33,6 +33,51 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		const sysInfoData = await this.sysInfo.getSysInfo(config);
 
 		result = result.concat(
+			this.processSysInfoItem({
+				item: sysInfoData.gitVer,
+				infoMessage: "Git is installed and is configured properly.",
+				warningMessage: "Git is not installed or not configured properly.",
+				additionalInformation: "You will not be able to create and work with Screen Builder projects." + EOL
+					+ "To be able to work with Screen Builder projects, download and install Git as described" + EOL
+					+ "in https://git-scm.com/downloads and add the git executable to your PATH.",
+				platforms: Constants.SUPPORTED_PLATFORMS
+			})
+		);
+
+		if (config && config.platform === Constants.ANDROID_PLATFORM_NAME) {
+			result = result.concat(this.getAndroidInfos(sysInfoData));
+		}
+
+		if (config && config.platform === Constants.IOS_PLATFORM_NAME) {
+			result = result.concat(await this.getiOSInfos(sysInfoData));
+		}
+
+		if (!config || !config.platform) {
+			result = result.concat(this.getAndroidInfos(sysInfoData), await this.getiOSInfos(sysInfoData));
+		}
+
+		if (!this.hostInfo.isDarwin) {
+			result.push({
+				message: "Local builds for iOS can be executed only on a macOS system. To build for iOS on a different operating system, you can use the NativeScript cloud infrastructure.",
+				additionalInformation: "",
+				platforms: [Constants.IOS_PLATFORM_NAME],
+				type: Constants.INFO_TYPE_NAME
+			});
+		}
+
+		return result;
+	}
+
+	public async getWarnings(config?: NativeScriptDoctor.ISysInfoConfig): Promise<NativeScriptDoctor.IWarning[]> {
+		const info = await this.getInfos(config);
+		return info.filter(item => item.type === Constants.WARNING_TYPE_NAME)
+			.map(item => this.convertInfoToWarning(item));
+	}
+
+	private getAndroidInfos(sysInfoData: NativeScriptDoctor.ISysInfoData): NativeScriptDoctor.IInfo[] {
+		let result: NativeScriptDoctor.IInfo[] = [];
+
+		result = result.concat(
 			this.processValidationErrors({
 				warnings: this.androidToolsInfo.validateAndroidHomeEnvVariable(),
 				infoMessage: "Your ANDROID_HOME environment variable is set and points to correct directory.",
@@ -66,9 +111,24 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 				warnings: this.androidToolsInfo.validateJavacVersion(sysInfoData.javacVersion),
 				infoMessage: "Javac is installed and is configured properly.",
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
+			}),
+			this.processSysInfoItem({
+				item: sysInfoData.javacVersion,
+				infoMessage: "The Java Development Kit (JDK) is installed and is configured properly.",
+				warningMessage: "The Java Development Kit (JDK) is not installed or is not configured properly.",
+				additionalInformation: "You will not be able to work with the Android SDK and you might not be able" + EOL
+					+ "to perform some Android-related operations. To ensure that you can develop and" + EOL
+					+ "test your apps for Android, verify that you have installed the JDK as" + EOL
+					+ "described in http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html (for JDK 8).",
+				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			})
 		);
 
+		return result;
+	}
+
+	private async getiOSInfos(sysInfoData: NativeScriptDoctor.ISysInfoData): Promise<NativeScriptDoctor.IInfo[]> {
+		let result: NativeScriptDoctor.IInfo[] = [];
 		if (this.hostInfo.isDarwin) {
 			result = result.concat(
 				this.processSysInfoItem({
@@ -103,7 +163,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 					platforms: [Constants.IOS_PLATFORM_NAME]
 				})
 			);
-
+	
 			if (sysInfoData.xcodeVer && sysInfoData.cocoaPodsVer) {
 				let isCocoaPodsWorkingCorrectly = await this.sysInfo.isCocoaPodsWorkingCorrectly();
 				result = result.concat(
@@ -116,7 +176,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 					})
 				);
 			}
-
+	
 			result = result.concat(
 				this.processSysInfoItem({
 					item: !sysInfoData.cocoaPodsVer || !semver.valid(sysInfoData.cocoaPodsVer) || !semver.lt(sysInfoData.cocoaPodsVer, Doctor.MIN_SUPPORTED_POD_VERSION),
@@ -144,44 +204,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 			);
 		}
 
-		result = result.concat(
-			this.processSysInfoItem({
-				item: sysInfoData.javacVersion,
-				infoMessage: "The Java Development Kit (JDK) is installed and is configured properly.",
-				warningMessage: "The Java Development Kit (JDK) is not installed or is not configured properly.",
-				additionalInformation: "You will not be able to work with the Android SDK and you might not be able" + EOL
-					+ "to perform some Android-related operations. To ensure that you can develop and" + EOL
-					+ "test your apps for Android, verify that you have installed the JDK as" + EOL
-					+ "described in http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html (for JDK 8).",
-				platforms: [Constants.ANDROID_PLATFORM_NAME]
-			}),
-			this.processSysInfoItem({
-				item: sysInfoData.gitVer,
-				infoMessage: "Git is installed and is configured properly.",
-				warningMessage: "Git is not installed or not configured properly.",
-				additionalInformation: "You will not be able to create and work with Screen Builder projects." + EOL
-					+ "To be able to work with Screen Builder projects, download and install Git as described" + EOL
-					+ "in https://git-scm.com/downloads and add the git executable to your PATH.",
-				platforms: Constants.SUPPORTED_PLATFORMS
-			})
-		);
-
-		if (!this.hostInfo.isDarwin) {
-			result.push({
-				message: "Local builds for iOS can be executed only on a macOS system. To build for iOS on a different operating system, you can use the NativeScript cloud infrastructure.",
-				additionalInformation: "",
-				platforms: [Constants.IOS_PLATFORM_NAME],
-				type: Constants.INFO_TYPE_NAME
-			});
-		}
-
 		return result;
-	}
-
-	public async getWarnings(config?: NativeScriptDoctor.ISysInfoConfig): Promise<NativeScriptDoctor.IWarning[]> {
-		const info = await this.getInfos(config);
-		return info.filter(item => item.type === Constants.WARNING_TYPE_NAME)
-			.map(item => this.convertInfoToWarning(item));
 	}
 
 	private processSysInfoItem(data: { item: string | boolean, infoMessage: string, warningMessage: string, additionalInformation?: string, platforms: string[] }): NativeScriptDoctor.IInfo {

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -9,7 +9,6 @@ import * as path from "path";
 import * as osenv from "osenv";
 import * as temp from "temp";
 import * as semver from "semver";
-import { constants } from "zlib";
 import { Constants } from "./constants";
 
 export class SysInfo implements NativeScriptDoctor.ISysInfo {

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -4,7 +4,6 @@ import { EOL } from "os";
 import { SysInfo } from "../lib/sys-info";
 import { Helpers } from "../lib/helpers";
 import { ChildProcess } from "../lib/wrappers/child-process";
-import { constants } from "zlib";
 
 const JavaHomeName = "JAVA_HOME";
 const AndroidHomeName = "ANDROID_HOME";

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -4,6 +4,7 @@ import { EOL } from "os";
 import { SysInfo } from "../lib/sys-info";
 import { Helpers } from "../lib/helpers";
 import { ChildProcess } from "../lib/wrappers/child-process";
+import { constants } from "zlib";
 
 const JavaHomeName = "JAVA_HOME";
 const AndroidHomeName = "ANDROID_HOME";
@@ -491,6 +492,75 @@ ${expectedCliVersion}`;
 					sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: false, dotNetVersion });
 					await assertAllValuesAreNull();
 				});
+			});
+		});
+
+		describe("returns correct sysInfo when", () => {
+			const assertCommonSysInfo = (result: NativeScriptDoctor.ISysInfoData) => {
+				assert.deepEqual(result.npmVer, childProcessResult.npmV.result.stdout);
+				assert.deepEqual(result.nodeVer, "6.0.0");
+				assert.deepEqual(result.nodeGypVer, childProcessResult.nodeGypVersion.result.stdout);
+				assert.deepEqual(result.gitVer, "1.9.5");
+				assert.deepEqual(result.nativeScriptCliVersion, childProcessResult.nativeScriptCliVersion.result.stdout);
+			};
+
+			const assertAndroidSysInfo = (result: NativeScriptDoctor.IAndroidSysInfoData) => {
+				assert.deepEqual(result.adbVer, "1.0.32");
+				assert.deepEqual(result.androidInstalled, false);
+				assert.deepEqual(result.monoVer, "1.0.6");
+				assert.deepEqual(result.gradleVer, "2.8");
+				assert.deepEqual(result.javacVersion, "1.8.0_60");
+				assert.deepEqual(result.isAndroidSdkConfiguredCorrectly, undefined);
+			};
+
+			const assertiOSSysInfo = (result: NativeScriptDoctor.IiOSSysInfoData) => {
+				assert.deepEqual(result.xcodeVer, "6.4.0");
+				assert.deepEqual(result.itunesInstalled, undefined);
+				assert.deepEqual(result.cocoaPodsVer, "0.38.2");
+				assert.deepEqual(result.xcodeprojLocation, null);
+				assert.deepEqual(result.isCocoaPodsWorkingCorrectly, undefined);
+				assert.deepEqual(result.xcprojInfo, undefined);
+				assert.deepEqual(result.isCocoaPodsUpdateRequired, false);
+				assert.deepEqual(result.pythonInfo, {isInstalled: false, isSixPackageInstalled: false, installationErrorMessage: "Cannot read property 'shouldThrowError' of undefined"});
+			};
+
+			it("iOS platform is specified", async () => {
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion });
+				const result = await sysInfo.getSysInfo({platform: "iOS"});
+
+				assertCommonSysInfo(result);
+				assertiOSSysInfo(result);
+				// Android specific properties should be undefined
+				assert.deepEqual(result.adbVer, undefined);
+				assert.deepEqual(result.androidInstalled, undefined);
+				assert.deepEqual(result.monoVer, undefined);
+				assert.deepEqual(result.gradleVer, undefined);
+				assert.deepEqual(result.javacVersion, undefined);
+				assert.deepEqual(result.isAndroidSdkConfiguredCorrectly, undefined);
+			});
+			it("Android platform is specified", async () => {
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion });
+				const result = await sysInfo.getSysInfo({platform: "Android"});
+
+				assertCommonSysInfo(result);
+				assertAndroidSysInfo(result);
+				// iOS specific properties should be undefined
+				assert.deepEqual(result.xcodeVer, undefined);
+				assert.deepEqual(result.itunesInstalled, undefined);
+				assert.deepEqual(result.cocoaPodsVer, undefined);
+				assert.deepEqual(result.xcodeprojLocation, undefined);
+				assert.deepEqual(result.isCocoaPodsWorkingCorrectly, undefined);
+				assert.deepEqual(result.xcprojInfo, undefined);
+				assert.deepEqual(result.isCocoaPodsUpdateRequired, undefined);
+				assert.deepEqual(result.pythonInfo, undefined);
+				
+			});
+			it("no platform is specified", async() => {
+				sysInfo = mockSysInfo(childProcessResult, { isWindows: false, isDarwin: true, dotNetVersion });
+				const result = await sysInfo.getSysInfo();
+				assertCommonSysInfo(result);
+				assertAndroidSysInfo(result);
+				assertiOSSysInfo(result);
 			});
 		});
 	});

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -141,10 +141,14 @@ declare module NativeScriptDoctor {
 
 	interface ISysInfoConfig {
 		/**
+		 * The platform for which to check if environment is properly configured.
+		 */
+		platform?: string;
+		/**
 		 * Path to package.json file of NativeScript CLI
 		 * @type {string}
 		 */
-		pathToNativeScriptCliPackageJson: string;
+		pathToNativeScriptCliPackageJson?: string;
 		/**
 		 * Android tools data
 		 * @type {{pathToAdb: string}}
@@ -177,158 +181,141 @@ declare module NativeScriptDoctor {
 
 		/**
 		 * Executes all checks for the current environment and returns the info from each check
+		 * @param {NativeScriptDoctor.ISysInfoConfig}
 		 * @return {Promise<IInfo[]>} Array of all the infos from all checks.
 		 */
-		getInfos(): Promise<IInfo[]>;
+		getInfos(config?: NativeScriptDoctor.ISysInfoConfig): Promise<IInfo[]>;
 	}
 
-	interface ISysInfoData {
-		// os stuff
+	interface ICommonSysInfoData {
 		/**
 		 * Os platform flavour, reported by os.platform.
 		 * @type {string}
 		 */
 		platform: string;
-
 		/**
 		 * Full os name, like `uname -a` on unix, registry query on win.
 		 * @type {string}
 		 */
 		os: string;
-
-		/**
-		 * .net version, applicable to windows only.
-		 * @type {string}
-		 */
-		dotNetVer: string;
-
 		/**
 		 * The command shell in use, usually bash or cmd.
 		 * @type {string}
 		 */
 		shell: string;
-
-		// node stuff
 		/**
 		 * node.js version, returned by node -v.
 		 * @type {string}
 		 */
 		nodeVer: string;
-
 		/**
 		 * npm version, returned by `npm -v`.
 		 * @type {string}
 		 */
 		npmVer: string;
-
 		/**
 		 * Process architecture, returned by `process.arch`.
 		 * @type {string}
 		 */
 		procArch: string;
-
 		/**
 		 * node-gyp version as returned by `node-gyp -v`.
 		 * @type {string}
 		 */
 		nodeGypVer: string;
-
-		// dependencies
-		/**
-		 * Xcode version string as returned by `xcodebuild -version`. Valid only on Mac.
-		 * @type {string}
-		 */
-		xcodeVer: string;
-
-		/**
-		 * Version string of adb, as returned by `adb version`.
-		 * @type {string}
-		 */
-		adbVer: string;
-
-		/**
-		 * Whether iTunes is installed on the machine.
-		 * @type {boolean}
-		 */
-		itunesInstalled: boolean;
-
-		/**
-		 * Whether `android` executable can be run.
-		 * @type {boolean}
-		 */
-		androidInstalled: boolean;
-
-		/**
-		 * mono version, relevant on Mac only.
-		 * @type {string}
-		 */
-		monoVer: string;
-
 		/**
 		 * git version string, as returned by `git --version`.
 		 * @type {string}
 		 */
 		gitVer: string;
-
-		/**
-		 * gradle version string as returned by `gradle -v`.
-		 * @type {string}
-		 */
-		gradleVer: string;
-
-		/**
-		 * javac version string as returned by `javac -version`.
-		 * @type {string}
-		 */
-		javacVersion: string;
-
-		/**
-		 * pod version string, as returned by `pod --version`.
-		 * @type {string}
-		 */
-		cocoaPodsVer: string;
-
-		/**
-		 * xcodeproj location, as returned by `which xcodeproj`.
-		 * @type {string}
-		 */
-		xcodeprojLocation: string;
-
-		/**
-		 * true id CocoaPods can successfully execute pod install.
-		 * @type {boolean}
-		 */
-		isCocoaPodsWorkingCorrectly: boolean;
-
 		/**
 		 * NativeScript CLI version string, as returned by `tns --version`.
 		 * @type {string}
 		 */
 		nativeScriptCliVersion: string;
+	}
 
+	interface IiOSSysInfoData {
+		/**
+		 * Xcode version string as returned by `xcodebuild -version`. Valid only on Mac.
+		 * @type {string}
+		 */
+		xcodeVer: string;
+		/**
+		 * Whether iTunes is installed on the machine.
+		 * @type {boolean}
+		 */
+		itunesInstalled: boolean;
+		/**
+		 * pod version string, as returned by `pod --version`.
+		 * @type {string}
+		 */
+		cocoaPodsVer: string;
+		/**
+		 * xcodeproj location, as returned by `which xcodeproj`.
+		 * @type {string}
+		 */
+		xcodeprojLocation: string;
+		/**
+		 * true id CocoaPods can successfully execute pod install.
+		 * @type {boolean}
+		 */
+		isCocoaPodsWorkingCorrectly: boolean;
 		/**
 		 * Information about xcproj.
 		 * @type {string}
 		 */
 		xcprojInfo: IXcprojInfo;
-
 		/**
 		 * true if the system requires xcproj to build projects successfully and the CocoaPods version is not compatible with the Xcode.
 		 * @type {boolean}
 		 */
 		isCocoaPodsUpdateRequired: boolean;
-
-		/**
-		 * true if the Android SDK Tools are installed and configured correctly.
-		 * @type {boolean}
-		 */
-		isAndroidSdkConfiguredCorrectly: boolean;
-
 		/**
 		 * Information about python installation
 		 */
 		pythonInfo: IPythonInfo;
 	}
+
+	interface IAndroidSysInfoData {
+		/**
+		 * Version string of adb, as returned by `adb version`.
+		 * @type {string}
+		 */
+		adbVer: string;
+		/**
+		 * Whether `android` executable can be run.
+		 * @type {boolean}
+		 */
+		androidInstalled: boolean;
+		/**
+		 * mono version, relevant on Mac only.
+		 * @type {string}
+		 */
+		monoVer: string;
+		/**
+		 * gradle version string as returned by `gradle -v`.
+		 * @type {string}
+		 */
+		gradleVer: string;
+		/**
+		 * javac version string as returned by `javac -version`.
+		 * @type {string}
+		 */
+		javacVersion: string;
+		/**
+		 * true if the Android SDK Tools are installed and configured correctly.
+		 * @type {boolean}
+		 */
+		isAndroidSdkConfiguredCorrectly: boolean;
+		/**
+		 * .net version, applicable to windows only.
+		 * @type {string}
+		 */
+		dotNetVer?: string;
+	}
+
+	interface ISysInfoData extends ICommonSysInfoData, IiOSSysInfoData, IAndroidSysInfoData { }
 
 	/**
 	 * Describes warning returned from nativescript-doctor check.


### PR DESCRIPTION
In case when android platform is specified, checks only android related things. In case when iOS platform is specified, checks only iOS related things. When no platform is specified, checks both Android and iOS things. This will improve the time {N} CLI needs to check if environment is correctly configured for platform specific commands. This also will fix failing cloud builds.