### PR TITLE
feat: Validate Javac version with Android runtime version

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Library that helps identifying if the environment can be used for development of
 		const pythonInfo = await sysInfo.getPythonInfo();
 		console.log("python info: ", pythonInfo );
 
-		const sysInfoData = await sysInfo.getSysInfo();
+		const sysInfoData = await sysInfo.getSysInfo({ projectDir: "/Users/username/myProject" });
 		console.log("sysInfo: ", sysInfoData);
 
 		const gitPath = await sysInfo.getGitPath();
@@ -454,12 +454,13 @@ Library that helps identifying if the environment can be used for development of
 	import { androidToolsInfo } from "nativescript-doctor"
 
 	function main() {
+		const projectDir = "/Users/username/myProject";
 		console.log("path to adb from android home: ", await androidToolsInfo.getPathToAdbFromAndroidHome());
 		console.log("path to emulator executable: ", androidToolsInfo.getPathToEmulatorExecutable());
 		console.log("android tools info: ", androidToolsInfo.getToolsInfo());
 		console.log("ANROID_HOME validation errors: ", await androidToolsInfo.validateAndroidHomeEnvVariable());
 		console.log("android tools info validation errors: ", await androidToolsInfo.validateInfo());
-		console.log("javac validation errors: ", await androidToolsInfo.validateJavacVersion(await sysInfo.getJavaCompilerVersion()));
+		console.log("javac validation errors: ", await androidToolsInfo.validateJavacVersion(await sysInfo.getJavaCompilerVersion(), projectDir));
 	}
 
 	main();
@@ -478,16 +479,20 @@ Library that helps identifying if the environment can be used for development of
 
 		/**
 		 * Checks if the Android tools are valid.
+		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
+		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateInfo(): NativeScriptDoctor.IWarning[];
+		validateInfo(projectDir?: string): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Checks if the current javac version is valid.
 		 * @param {string} installedJavaVersion The version of javac to check.
+		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
+		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateJavacVersion(installedJavaVersion: string): NativeScriptDoctor.IWarning[];
+		validateJavacVersion(installedJavaVersion: string, projectDir?: string): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Returns the path to the adb which is located in ANDROID_HOME.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,4 +9,9 @@ export class Constants {
 	};
 	public static INFO_TYPE_NAME = "info";
 	public static WARNING_TYPE_NAME = "warning";
+
+	public static PACKAGE_JSON = "package.json";
+	public static NATIVESCRIPT_KEY = "nativescript";
+	public static ANDROID_RUNTIME = "tns-android";
+	public static VERSION_PROPERTY_NAME = "version";
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -66,3 +66,16 @@ interface IHiveIds {
 interface IDictionary<T> {
 	[key: string]: T
 }
+
+interface IVersion {
+	version: string;
+}
+
+interface INativeScriptNode {
+	["tns-android"]: IVersion;
+	["tns-ios"]: IVersion;
+}
+
+interface INativeScriptProjectPackageJson {
+	nativescript: INativeScriptNode;
+}

--- a/lib/doctor.ts
+++ b/lib/doctor.ts
@@ -16,11 +16,11 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		private sysInfo: NativeScriptDoctor.ISysInfo,
 		private androidToolsInfo: NativeScriptDoctor.IAndroidToolsInfo) { }
 
-	public async canExecuteLocalBuild(platform: string): Promise<boolean> {
+	public async canExecuteLocalBuild(platform: string, projectDir?: string): Promise<boolean> {
 		this.validatePlatform(platform);
 
 		if (platform.toLowerCase() === Constants.ANDROID_PLATFORM_NAME.toLowerCase()) {
-			return await this.androidLocalBuildRequirements.checkRequirements();
+			return await this.androidLocalBuildRequirements.checkRequirements(projectDir);
 		} else if (platform.toLowerCase() === Constants.IOS_PLATFORM_NAME.toLowerCase()) {
 			return await this.iOSLocalBuildRequirements.checkRequirements();
 		}
@@ -33,7 +33,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		const sysInfoData = await this.sysInfo.getSysInfo(config);
 
 		if (!config || !config.platform || config.platform === Constants.ANDROID_PLATFORM_NAME) {
-			result = result.concat(this.getAndroidInfos(sysInfoData));
+			result = result.concat(this.getAndroidInfos(sysInfoData, config && config.projectDir));
 		}
 
 		if (!config || !config.platform || config.platform === Constants.IOS_PLATFORM_NAME) {
@@ -58,7 +58,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 			.map(item => this.convertInfoToWarning(item));
 	}
 
-	private getAndroidInfos(sysInfoData: NativeScriptDoctor.ISysInfoData): NativeScriptDoctor.IInfo[] {
+	private getAndroidInfos(sysInfoData: NativeScriptDoctor.ISysInfoData, projectDir?: string): NativeScriptDoctor.IInfo[] {
 		let result: NativeScriptDoctor.IInfo[] = [];
 
 		result = result.concat(
@@ -92,7 +92,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			}),
 			this.processValidationErrors({
-				warnings: this.androidToolsInfo.validateJavacVersion(sysInfoData.javacVersion),
+				warnings: this.androidToolsInfo.validateJavacVersion(sysInfoData.javacVersion, projectDir),
 				infoMessage: "Javac is installed and is configured properly.",
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			}),

--- a/lib/local-build-requirements/android-local-build-requirements.ts
+++ b/lib/local-build-requirements/android-local-build-requirements.ts
@@ -2,11 +2,13 @@ export class AndroidLocalBuildRequirements {
 	constructor(private androidToolsInfo: NativeScriptDoctor.IAndroidToolsInfo,
 		private sysInfo: NativeScriptDoctor.ISysInfo) { }
 
-	public async checkRequirements(): Promise<boolean> {
+	public async checkRequirements(projectDir?: string): Promise<boolean> {
 		const androidToolsInfo = await this.androidToolsInfo.validateInfo();
+		const javacVersion =  await this.sysInfo.getJavaCompilerVersion();
 		if (androidToolsInfo.length ||
-			!await this.sysInfo.getJavaCompilerVersion() ||
-			!await this.sysInfo.getAdbVersion()) {
+			!javacVersion ||
+			!await this.sysInfo.getAdbVersion() ||
+			!await this.androidToolsInfo.validateJavacVersion(javacVersion, projectDir)) {
 			return false;
 		}
 

--- a/lib/wrappers/child-process.ts
+++ b/lib/wrappers/child-process.ts
@@ -76,6 +76,10 @@ export class ChildProcess {
 		});
 	}
 
+	public execSync(command: string, options?: childProcess.ExecSyncOptions): string {
+		return childProcess.execSync(command, options).toString();
+	}
+
 	public execFile(command: string, args: string[]): Promise<any> {
 		return new Promise<any>((resolve, reject) => {
 			childProcess.execFile(command, args, (error, stdout) => {

--- a/lib/wrappers/file-system.ts
+++ b/lib/wrappers/file-system.ts
@@ -17,4 +17,9 @@ export class FileSystem {
 	public readDirectory(path: string): string[] {
 		return fs.readdirSync(path);
 	}
+
+	public readJson<T>(path: string, options?: { encoding?: null; flag?: string; }): T {
+		const content = fs.readFileSync(path, options);
+		return JSON.parse(content.toString());
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.1.0-rc.0",
+  "version": "1.1.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/android-tools-info.ts
+++ b/test/android-tools-info.ts
@@ -10,16 +10,30 @@ import { Constants } from '../lib/constants';
 interface ITestData {
 	javacVersion: string;
 	warnings?: string[];
+	runtimeVersion?: string;
+	additionalInformation?: string;
 }
 
 describe("androidToolsInfo", () => {
-	const additionalInformation = "You will not be able to build your projects for Android." + EOL
-	+ "To be able to build for Android, verify that you have installed The Java Development Kit (JDK) and configured it according to system requirements as" + EOL +
-	" described in " + Constants.SYSTEM_REQUIREMENTS_LINKS[process.platform];
+	const defaultAdditionalInformation = "You will not be able to build your projects for Android." + EOL
+		+ "To be able to build for Android, verify that you have installed The Java Development Kit (JDK) and configured it according to system requirements as" + EOL +
+		" described in " + Constants.SYSTEM_REQUIREMENTS_LINKS[process.platform];
 
-	const getAndroidToolsInfo = (): AndroidToolsInfo => {
+	const getAndroidToolsInfo = (runtimeVersion?: string): AndroidToolsInfo => {
 		const childProcess: ChildProcess = <any>{};
-		const fs: FileSystem = <any>{};
+		const fs: FileSystem = <any>{
+			exists: () => true,
+			execSync: (): string => null,
+			readJson: (): any => {
+				return runtimeVersion ? {
+					nativescript: {
+						"tns-android": {
+							version: runtimeVersion
+						}
+					}
+				} : null;
+			}
+		};
 		const hostInfo: HostInfo = <any>{};
 		const helpers: Helpers = new Helpers(<any>{});
 		return new AndroidToolsInfo(childProcess, fs, hostInfo, helpers);
@@ -56,25 +70,130 @@ describe("androidToolsInfo", () => {
 			{
 				javacVersion: null,
 				warnings: ["Error executing command 'javac'. Make sure you have installed The Java Development Kit (JDK) and set JAVA_HOME environment variable."]
+			},
+			{
+				javacVersion: "10",
+				runtimeVersion: "4.0.0",
+				warnings: [`The Java compiler version 10 is not compatible with the current Android runtime version 4.0.0. ` +
+					`In order to use this Javac version, you need to update your Android runtime or downgrade your Java compiler version.`],
+				additionalInformation: "You will not be able to build your projects for Android." + EOL +
+					"To be able to build for Android, downgrade your Java compiler version or update your Android runtime."
+			},
+			{
+				javacVersion: "10",
+				runtimeVersion: "4.2.0"
 			}
 		];
 
-		testData.forEach(({ javacVersion, warnings }) => {
+		testData.forEach(({ javacVersion, warnings, runtimeVersion, additionalInformation }) => {
 			it(`returns correct result when version is ${javacVersion}`, () => {
-				const androidToolsInfo = getAndroidToolsInfo();
-				const actualWarnings = androidToolsInfo.validateJavacVersion(javacVersion);
+				const androidToolsInfo = getAndroidToolsInfo(runtimeVersion);
+				const actualWarnings = androidToolsInfo.validateJavacVersion(javacVersion, "/Users/username/projectDir");
+
 				let expectedWarnings: NativeScriptDoctor.IWarning[] = [];
 				if (warnings && warnings.length) {
 					expectedWarnings = warnings.map(warning => {
 						return {
 							platforms: [Constants.ANDROID_PLATFORM_NAME],
 							warning,
-							additionalInformation
+							additionalInformation: additionalInformation || defaultAdditionalInformation
 						};
 					});
 				}
 
 				assert.deepEqual(actualWarnings, expectedWarnings);
+			});
+		});
+
+		const npmTagsTestData: ITestData[] = [
+			{
+				javacVersion: "1.8.0",
+				runtimeVersion: "rc"
+			},
+			{
+				javacVersion: "10",
+				runtimeVersion: "rc"
+			},
+			{
+				javacVersion: "10",
+				runtimeVersion: "latest",
+				warnings: [`The Java compiler version 10 is not compatible with the current Android runtime version 4.0.0. ` +
+					`In order to use this Javac version, you need to update your Android runtime or downgrade your Java compiler version.`],
+				additionalInformation: "You will not be able to build your projects for Android." + EOL +
+					"To be able to build for Android, downgrade your Java compiler version or update your Android runtime."
+			},
+			{
+				javacVersion: "10",
+				runtimeVersion: "old",
+				warnings: [`The Java compiler version 10 is not compatible with the current Android runtime version 4.1.0-2018.5.17.1. ` +
+					`In order to use this Javac version, you need to update your Android runtime or downgrade your Java compiler version.`],
+				additionalInformation: "You will not be able to build your projects for Android." + EOL +
+					"To be able to build for Android, downgrade your Java compiler version or update your Android runtime."
+			},
+			{
+				javacVersion: "10",
+				runtimeVersion: "old",
+				warnings: [`The Java compiler version 10 is not compatible with the current Android runtime version 4.1.0-2018.5.17.1. ` +
+					`In order to use this Javac version, you need to update your Android runtime or downgrade your Java compiler version.`],
+				additionalInformation: "You will not be able to build your projects for Android." + EOL +
+					"To be able to build for Android, downgrade your Java compiler version or update your Android runtime."
+			},
+			{
+				javacVersion: "1.8.0",
+				runtimeVersion: "latest"
+			},
+			{
+				javacVersion: "1.8.0",
+				runtimeVersion: "old"
+			},
+		];
+
+		npmTagsTestData.forEach(({ javacVersion, warnings, runtimeVersion, additionalInformation }) => {
+			it(`returns correct result when javac version is ${javacVersion} and the runtime version is tag from npm: ${runtimeVersion}`, () => {
+				let execSyncCommand: string = null;
+				const childProcess: ChildProcess = <any>{
+					execSync: (command: string) => {
+						execSyncCommand = command;
+						return JSON.stringify({
+							latest: '4.0.0',
+							rc: '4.1.0-rc-2018.5.21.1',
+							next: '4.1.0-2018.5.23.2',
+							old: '4.1.0-2018.5.17.1'
+						});
+					}
+				};
+
+				const fs: FileSystem = <any>{
+					exists: (filePath: string): boolean => true,
+					execSync: (): string => null,
+					readJson: (): any =>
+						({
+							nativescript: {
+								"tns-android": {
+									version: runtimeVersion
+								}
+							}
+						})
+				};
+
+				const hostInfo: HostInfo = <any>{};
+				const helpers: Helpers = new Helpers(<any>{});
+				const androidToolsInfo = new AndroidToolsInfo(childProcess, fs, hostInfo, helpers);
+
+				const actualWarnings = androidToolsInfo.validateJavacVersion(javacVersion, "/Users/username/projectDir");
+				let expectedWarnings: NativeScriptDoctor.IWarning[] = [];
+				if (warnings && warnings.length) {
+					expectedWarnings = warnings.map(warning => {
+						return {
+							platforms: [Constants.ANDROID_PLATFORM_NAME],
+							warning,
+							additionalInformation: additionalInformation || defaultAdditionalInformation
+						};
+					});
+				}
+
+				assert.deepEqual(actualWarnings, expectedWarnings);
+				assert.equal(execSyncCommand, "npm view tns-android dist-tags --json");
 			});
 		});
 	});

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -145,7 +145,8 @@ function mockSysInfo(childProcessResult: IChildProcessResults, hostInfoOptions?:
 		},
 		execFile: async (): Promise<any> => {
 			return undefined;
-		}
+		},
+		execSync: (command: string): string => null
 	};
 
 	const fileSystem: any = {
@@ -191,7 +192,8 @@ describe("SysInfo unit tests", () => {
 				},
 				execFile: async () => {
 					return undefined;
-				}
+				},
+				execSync: (command: string): string => null
 			};
 
 			const helpers = new Helpers(null);

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -160,6 +160,12 @@ declare module NativeScriptDoctor {
 			 */
 			pathToAdb: string;
 		};
+
+		/**
+		 * The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
+		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
+		 */
+		projectDir?: string;
 	}
 
 	/**
@@ -424,16 +430,20 @@ declare module NativeScriptDoctor {
 
 		/**
 		 * Checks if the Android tools are valid.
+		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
+		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateInfo(): NativeScriptDoctor.IWarning[];
+		validateInfo(projectDir?: string): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Checks if the current javac version is valid.
 		 * @param {string} installedJavaVersion The version of javac to check.
+		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
+		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateJavacVersion(installedJavaVersion: string): NativeScriptDoctor.IWarning[];
+		validateJavacVersion(installedJavaVersion: string, projectDir?: string): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Returns the path to the adb which is located in ANDROID_HOME.


### PR DESCRIPTION
In NativeScript 4.1.0 we add support for Java 10. However, older versions of the Android runtime cannot work with Java 10, so verification for the current environment and local builds depends on the current Android runtime version.
In order to handle this, add projectDir parameter to the API. In case it is passed, we'll check if Android Runtime version is specified in the package.json and we'll verify if it is supported for the current Java version.