### PR TITLE
feat: Validate Java version based on passed runtime version

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -38,7 +38,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 		return this.toolsInfo;
 	}
 
-	public validateInfo(projectDir?: string): NativeScriptDoctor.IWarning[] {
+	public validateInfo(): NativeScriptDoctor.IWarning[] {
 		const errors: NativeScriptDoctor.IWarning[] = [];
 		const toolsInfoData = this.getToolsInfo();
 		const isAndroidHomeValid = this.isAndroidHomeValid();
@@ -88,7 +88,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 		return errors;
 	}
 
-	public validateJavacVersion(installedJavaCompilerVersion: string, projectDir?: string): NativeScriptDoctor.IWarning[] {
+	public validateJavacVersion(installedJavaCompilerVersion: string, projectDir?: string, runtimeVersion?: string): NativeScriptDoctor.IWarning[] {
 		const errors: NativeScriptDoctor.IWarning[] = [];
 
 		let additionalMessage = "You will not be able to build your projects for Android." + EOL
@@ -107,7 +107,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			if (semver.lt(installedJavaCompilerSemverVersion, AndroidToolsInfo.MIN_JAVA_VERSION)) {
 				warning = `Javac version ${installedJavaCompilerVersion} is not supported. You have to install at least ${AndroidToolsInfo.MIN_JAVA_VERSION}.`;
 			} else {
-				const runtimeVersion = this.getAndroidRuntimeVersionFromProjectDir(projectDir);
+				runtimeVersion = this.getRealRuntimeVersion(runtimeVersion || this.getAndroidRuntimeVersionFromProjectDir(projectDir));
 				if (runtimeVersion) {
 					// get the item from the dictionary that corresponds to our current Javac version:
 					let runtimeMinVersion: string = null;
@@ -355,6 +355,10 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			}
 		}
 
+		return runtimeVersion;
+	}
+
+	private getRealRuntimeVersion(runtimeVersion: string): string {
 		if (runtimeVersion) {
 			// Check if the version is not "next" or "rc", i.e. tag from npm
 			if (!semver.valid(runtimeVersion)) {
@@ -370,7 +374,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 
 		if (runtimeVersion && !semver.valid(runtimeVersion)) {
 			// If we got here, something terribly wrong happened.
-			throw new Error(`The determined Android runtime version ${runtimeVersion} based on project directory ${projectDir} is not valid. Unable to verify if the current system is setup for Android development.`);
+			throw new Error(`The determined Android runtime version ${runtimeVersion} is not valid. Unable to verify if the current system is setup for Android development.`);
 		}
 
 		return runtimeVersion;

--- a/lib/doctor.ts
+++ b/lib/doctor.ts
@@ -16,11 +16,11 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		private sysInfo: NativeScriptDoctor.ISysInfo,
 		private androidToolsInfo: NativeScriptDoctor.IAndroidToolsInfo) { }
 
-	public async canExecuteLocalBuild(platform: string, projectDir?: string): Promise<boolean> {
+	public async canExecuteLocalBuild(platform: string, projectDir?: string, runtimeVersion?: string): Promise<boolean> {
 		this.validatePlatform(platform);
 
 		if (platform.toLowerCase() === Constants.ANDROID_PLATFORM_NAME.toLowerCase()) {
-			return await this.androidLocalBuildRequirements.checkRequirements(projectDir);
+			return await this.androidLocalBuildRequirements.checkRequirements(projectDir, runtimeVersion);
 		} else if (platform.toLowerCase() === Constants.IOS_PLATFORM_NAME.toLowerCase()) {
 			return await this.iOSLocalBuildRequirements.checkRequirements();
 		}
@@ -32,11 +32,11 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		let result: NativeScriptDoctor.IInfo[] = [];
 		const sysInfoData = await this.sysInfo.getSysInfo(config);
 
-		if (!config || !config.platform || config.platform === Constants.ANDROID_PLATFORM_NAME) {
-			result = result.concat(this.getAndroidInfos(sysInfoData, config && config.projectDir));
+		if (!config || !config.platform || config.platform.toLowerCase() === Constants.ANDROID_PLATFORM_NAME.toLowerCase()) {
+			result = result.concat(this.getAndroidInfos(sysInfoData, config && config.projectDir, config && config.androidRuntimeVersion));
 		}
 
-		if (!config || !config.platform || config.platform === Constants.IOS_PLATFORM_NAME) {
+		if (!config || !config.platform || config.platform.toLowerCase() === Constants.IOS_PLATFORM_NAME.toLowerCase()) {
 			result = result.concat(await this.getiOSInfos(sysInfoData));
 		}
 
@@ -58,7 +58,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 			.map(item => this.convertInfoToWarning(item));
 	}
 
-	private getAndroidInfos(sysInfoData: NativeScriptDoctor.ISysInfoData, projectDir?: string): NativeScriptDoctor.IInfo[] {
+	private getAndroidInfos(sysInfoData: NativeScriptDoctor.ISysInfoData, projectDir?: string, runtimeVersion?: string): NativeScriptDoctor.IInfo[] {
 		let result: NativeScriptDoctor.IInfo[] = [];
 
 		result = result.concat(
@@ -92,7 +92,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			}),
 			this.processValidationErrors({
-				warnings: this.androidToolsInfo.validateJavacVersion(sysInfoData.javacVersion, projectDir),
+				warnings: this.androidToolsInfo.validateJavacVersion(sysInfoData.javacVersion, projectDir, runtimeVersion),
 				infoMessage: "Javac is installed and is configured properly.",
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			}),

--- a/lib/local-build-requirements/android-local-build-requirements.ts
+++ b/lib/local-build-requirements/android-local-build-requirements.ts
@@ -2,13 +2,13 @@ export class AndroidLocalBuildRequirements {
 	constructor(private androidToolsInfo: NativeScriptDoctor.IAndroidToolsInfo,
 		private sysInfo: NativeScriptDoctor.ISysInfo) { }
 
-	public async checkRequirements(projectDir?: string): Promise<boolean> {
+	public async checkRequirements(projectDir?: string, runtimeVersion?: string): Promise<boolean> {
 		const androidToolsInfo = await this.androidToolsInfo.validateInfo();
 		const javacVersion =  await this.sysInfo.getJavaCompilerVersion();
 		if (androidToolsInfo.length ||
 			!javacVersion ||
 			!await this.sysInfo.getAdbVersion() ||
-			!await this.androidToolsInfo.validateJavacVersion(javacVersion, projectDir)) {
+			!await this.androidToolsInfo.validateJavacVersion(javacVersion, projectDir, runtimeVersion)) {
 			return false;
 		}
 

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -221,11 +221,11 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 	}
 
 	public async getSysInfo(config?: NativeScriptDoctor.ISysInfoConfig): Promise<NativeScriptDoctor.ISysInfoData> {
-		if (config && config.platform === Constants.ANDROID_PLATFORM_NAME) {
+		if (config && config.platform && config.platform.toLowerCase() === Constants.ANDROID_PLATFORM_NAME.toLowerCase()) {
 			return <NativeScriptDoctor.ISysInfoData>Object.assign(await this.getCommonSysInfo(), await this.getAndroidSysInfo(config));
 		}
 
-		if (config && config.platform === Constants.IOS_PLATFORM_NAME) {
+		if (config && config.platform && config.platform.toLowerCase() === Constants.IOS_PLATFORM_NAME.toLowerCase()) {
 			return <NativeScriptDoctor.ISysInfoData>Object.assign(await this.getCommonSysInfo(), await this.getiOSSysInfo());
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.1.0",
+  "version": "1.2.0-rc.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -168,7 +168,7 @@ declare module NativeScriptDoctor {
 		projectDir?: string;
 
 		/**
-		 * The runtime version against which the validation is executed. In case this parameter is passed, it takes predescences over the projectDir argument.
+		 * The runtime version against which the validation is executed. In case this parameter is passed, it takes precedence over the projectDir argument.
 		 */
 		androidRuntimeVersion?: string;
 	}
@@ -180,10 +180,12 @@ declare module NativeScriptDoctor {
 		/**
 		 * Checks if a local build can be executed on the current machine.
 		 * @param {string} platform The platform for which to check if local build is possible.
-		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes predescences over the projectDir argument.
+		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
+		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
+		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes precedence over the projectDir argument.
 		 * @return {Promise<boolean>} true if local build can be executed for the provided platform.
 		 */
-		canExecuteLocalBuild(platform: string, runtimeVersion?: string): Promise<boolean>;
+		canExecuteLocalBuild(platform: string, projectDir?: string, runtimeVersion?: string): Promise<boolean>;
 
 		/**
 		 * Executes all checks for the current environment and returns the warnings from each check.
@@ -445,7 +447,7 @@ declare module NativeScriptDoctor {
 		 * @param {string} installedJavaVersion The version of javac to check.
 		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
 		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
-		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes predescences over the projectDir argument.
+		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes precedence over the projectDir argument.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
 		validateJavacVersion(installedJavaVersion: string, projectDir?: string, runtimeVersion?: string): NativeScriptDoctor.IWarning[];

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -166,6 +166,11 @@ declare module NativeScriptDoctor {
 		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
 		 */
 		projectDir?: string;
+
+		/**
+		 * The runtime version against which the validation is executed. In case this parameter is passed, it takes predescences over the projectDir argument.
+		 */
+		androidRuntimeVersion?: string;
 	}
 
 	/**
@@ -175,9 +180,10 @@ declare module NativeScriptDoctor {
 		/**
 		 * Checks if a local build can be executed on the current machine.
 		 * @param {string} platform The platform for which to check if local build is possible.
+		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes predescences over the projectDir argument.
 		 * @return {Promise<boolean>} true if local build can be executed for the provided platform.
 		 */
-		canExecuteLocalBuild(platform: string): Promise<boolean>;
+		canExecuteLocalBuild(platform: string, runtimeVersion?: string): Promise<boolean>;
 
 		/**
 		 * Executes all checks for the current environment and returns the warnings from each check.
@@ -430,20 +436,19 @@ declare module NativeScriptDoctor {
 
 		/**
 		 * Checks if the Android tools are valid.
-		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
-		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateInfo(projectDir?: string): NativeScriptDoctor.IWarning[];
+		validateInfo(): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Checks if the current javac version is valid.
 		 * @param {string} installedJavaVersion The version of javac to check.
 		 * @param {string} projectDir @optional The project directory. Used to determine the Android Runtime version and validate the Java compiler version against it.
 		 * If it is not passed or the project does not have Android runtime, this validation is skipped.
+		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes predescences over the projectDir argument.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateJavacVersion(installedJavaVersion: string, projectDir?: string): NativeScriptDoctor.IWarning[];
+		validateJavacVersion(installedJavaVersion: string, projectDir?: string, runtimeVersion?: string): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Returns the path to the adb which is located in ANDROID_HOME.


### PR DESCRIPTION
Allow verification of the environment based on a specified Android runtime version. This is required for cases where the package.json of the project is not updated yet, but we need to verify that we can use this runtime