### PR TITLE
fix: Check for Local Android build disregards issues in Javac version

### DIFF
--- a/lib/local-build-requirements/android-local-build-requirements.ts
+++ b/lib/local-build-requirements/android-local-build-requirements.ts
@@ -4,11 +4,11 @@ export class AndroidLocalBuildRequirements {
 
 	public async checkRequirements(projectDir?: string, runtimeVersion?: string): Promise<boolean> {
 		const androidToolsInfo = await this.androidToolsInfo.validateInfo();
-		const javacVersion =  await this.sysInfo.getJavaCompilerVersion();
+		const javacVersion = await this.sysInfo.getJavaCompilerVersion();
+		const isJavacVersionInvalid = !javacVersion || (await this.androidToolsInfo.validateJavacVersion(javacVersion, projectDir, runtimeVersion)).length;
 		if (androidToolsInfo.length ||
-			!javacVersion ||
 			!await this.sysInfo.getAdbVersion() ||
-			!await this.androidToolsInfo.validateJavacVersion(javacVersion, projectDir, runtimeVersion)) {
+			isJavacVersionInvalid) {
 			return false;
 		}
 

--- a/test/android-local-build-requirements.ts
+++ b/test/android-local-build-requirements.ts
@@ -1,0 +1,95 @@
+import { AndroidLocalBuildRequirements } from '../lib/local-build-requirements/android-local-build-requirements';
+import { assert } from "chai";
+
+interface ITestCaseData {
+	testName: string;
+	validateInfo?: NativeScriptDoctor.IWarning[];
+	validateJavacVersion?: NativeScriptDoctor.IWarning[];
+	getJavaCompilerVersion?: string;
+	getAdbVersion?: string;
+}
+
+describe("androidLocalBuildRequirements", () => {
+	describe("checkRequirements", () => {
+		const setupTestCase = (results: ITestCaseData): AndroidLocalBuildRequirements => {
+			const androidToolsInfo: NativeScriptDoctor.IAndroidToolsInfo = {
+				validateInfo: (): NativeScriptDoctor.IWarning[] => results.validateInfo || [],
+				validateAndroidHomeEnvVariable: (): NativeScriptDoctor.IWarning[] => [],
+				getToolsInfo: (): NativeScriptDoctor.IAndroidToolsInfoData => null,
+				validateJavacVersion: (installedJavaVersion: string, projectDir?: string, runtimeVersion?: string): NativeScriptDoctor.IWarning[] => results.validateJavacVersion || [],
+				getPathToAdbFromAndroidHome: async (): Promise<string> => undefined,
+				getPathToEmulatorExecutable: (): string => undefined
+			};
+
+			const sysInfo: NativeScriptDoctor.ISysInfo = {
+				getJavaCompilerVersion: async (): Promise<string> => results.hasOwnProperty("getJavaCompilerVersion") ? results.getJavaCompilerVersion : "8.0.0",
+				getAdbVersion: async (pathToAdb?: string): Promise<string> => results.hasOwnProperty("getAdbVersion") ? results.getAdbVersion : "1.0.39",
+				getXcodeVersion: async (): Promise<string> => undefined,
+				getNodeVersion: async (): Promise<string> => undefined,
+				getNpmVersion: async (): Promise<string> => undefined,
+				getNodeGypVersion: async (): Promise<string> => undefined,
+				getXcodeprojLocation: async (): Promise<string> => undefined,
+				isITunesInstalled: async (): Promise<boolean> => false,
+				getCocoaPodsVersion: async (): Promise<string> => undefined,
+				getOs: async (): Promise<string> => undefined,
+				isAndroidInstalled: async (): Promise<boolean> => false,
+				getMonoVersion: async (): Promise<string> => undefined,
+				getGitVersion: async (): Promise<string> => undefined,
+				getGitPath: async (): Promise<string> => undefined,
+				getGradleVersion: async (): Promise<string> => undefined,
+				isCocoaPodsWorkingCorrectly: async (): Promise<boolean> => false,
+				getNativeScriptCliVersion: async (): Promise<string> => undefined,
+				getXcprojInfo: async (): Promise<NativeScriptDoctor.IXcprojInfo> => null,
+				isCocoaPodsUpdateRequired: async (): Promise<boolean> => true,
+				isAndroidSdkConfiguredCorrectly: async (): Promise<boolean> => true,
+				getSysInfo: async (config?: NativeScriptDoctor.ISysInfoConfig): Promise<NativeScriptDoctor.ISysInfoData> => null,
+				setShouldCacheSysInfo: (shouldCache: boolean): void => undefined
+			};
+
+			const androidLocalBuildRequirements = new AndroidLocalBuildRequirements(androidToolsInfo, sysInfo);
+			return androidLocalBuildRequirements;
+		};
+
+		it("returns true when everything is setup correctly", async () => {
+			const androidLocalBuildRequirements = setupTestCase({ testName: "returns true when everything is setup correctly" });
+			const result = await androidLocalBuildRequirements.checkRequirements();
+			assert.isTrue(result);
+		});
+
+		describe("returns false", () => {
+			const getWarnings = (): NativeScriptDoctor.IWarning[] => {
+				return [{
+					warning: "warning",
+					additionalInformation: "additional info",
+					platforms: ["android"]
+				}];
+			};
+			const testData: ITestCaseData[] = [
+				{
+					testName: "when java is not installed",
+					getJavaCompilerVersion: null
+				},
+				{
+					testName: "when java is installed, but it is not compatible for current project",
+					validateJavacVersion: getWarnings()
+				},
+				{
+					testName: "when Android tools are not installed correctly",
+					validateInfo: getWarnings()
+				},
+				{
+					testName: "when adb cannot be found",
+					getAdbVersion: null
+				}
+			];
+
+			testData.forEach(testCase => {
+				it(testCase.testName, async () => {
+					const androidLocalBuildRequirements = setupTestCase(testCase);
+					const result = await androidLocalBuildRequirements.checkRequirements();
+					assert.isFalse(result);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
In case there's a problem with Javac version (for example it is 10.0.0, but current project uses Android runtime, that cannot be used with this Java version), the checkRequirements method disregards the warning.
Fix the check and add tests.