### PR TITLE
feat: remove requirement for Android Support Repository installation

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -30,7 +30,6 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			infoData.androidHomeEnvVar = this.androidHome;
 			infoData.compileSdkVersion = this.getCompileSdk();
 			infoData.buildToolsVersion = this.getBuildToolsVersion();
-			infoData.supportRepositoryVersion = this.getAndroidSupportRepositoryVersion();
 
 			this.toolsInfo = infoData;
 		}
@@ -68,19 +67,6 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			errors.push({
 				warning: "You need to have the Android SDK Build-tools installed on your system. " + message,
 				additionalInformation: invalidBuildToolsAdditionalMsg,
-				platforms: [Constants.ANDROID_PLATFORM_NAME]
-			});
-		}
-
-		if (!toolsInfoData.supportRepositoryVersion) {
-			let invalidSupportLibAdditionalMsg = `Run \`\$ ${this.getPathToSdkManagementTool()}\` to manage the Android Support Repository.`;
-			if (!isAndroidHomeValid) {
-				invalidSupportLibAdditionalMsg += ' In case you already have it installed, make sure `ANDROID_HOME` environment variable is set correctly.';
-			}
-
-			errors.push({
-				warning: `You need to have Android SDK ${AndroidToolsInfo.MIN_REQUIRED_COMPILE_TARGET} or later and the latest Android Support Repository installed on your system.`,
-				additionalInformation: invalidSupportLibAdditionalMsg,
 				platforms: [Constants.ANDROID_PLATFORM_NAME]
 			});
 		}
@@ -273,31 +259,6 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 		}
 
 		return buildToolsVersion;
-	}
-
-	private getAppCompatRange(): string {
-		let compileSdkVersion = this.getCompileSdk();
-		let requiredAppCompatRange: string;
-		if (compileSdkVersion) {
-			requiredAppCompatRange = `>=${compileSdkVersion} <${compileSdkVersion + 1}`;
-		}
-
-		return requiredAppCompatRange;
-	}
-
-	private getAndroidSupportRepositoryVersion(): string {
-		let selectedAppCompatVersion: string;
-		const requiredAppCompatRange = this.getAppCompatRange();
-		if (this.androidHome && requiredAppCompatRange) {
-			const pathToAppCompat = path.join(this.androidHome, "extras", "android", "m2repository", "com", "android", "support", "appcompat-v7");
-			selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, requiredAppCompatRange);
-			if (!selectedAppCompatVersion) {
-				// get latest matching version, as there's no available appcompat versions for latest SDK versions.
-				selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, "*");
-			}
-		}
-
-		return selectedAppCompatVersion;
 	}
 
 	private getLatestValidAndroidTarget(): string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -489,10 +489,5 @@ declare module NativeScriptDoctor {
 		 * The latest installed version of Android SDK that satisfies CLI's requirements.
 		 */
 		compileSdkVersion: number;
-
-		/**
-		 * The latest installed version of Android Support Repository that satisfies CLI's requirements.
-		 */
-		supportRepositoryVersion: string;
 	}
 }


### PR DESCRIPTION
In the past there was a requirement to have a local copy of the Android Support Repository in order to use it in your application.
However, since some time the new versions of the libraries are in the Google repository, so there's no need to have them locally.