### PR TITLE
feat: drop support for Xcode versions below 9

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,4 +14,5 @@ export class Constants {
 	public static NATIVESCRIPT_KEY = "nativescript";
 	public static ANDROID_RUNTIME = "tns-android";
 	public static VERSION_PROPERTY_NAME = "version";
+	public static XCODE_MIN_REQUIRED_VERSION = 9;
 }

--- a/lib/doctor.ts
+++ b/lib/doctor.ts
@@ -186,6 +186,18 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 					platforms: [Constants.IOS_PLATFORM_NAME]
 				})
 			);
+
+			if (sysInfoData.xcodeVer) {
+				result = result.concat(
+					this.processSysInfoItem({
+						item: await this.iOSLocalBuildRequirements.isXcodeVersionValid(),
+						infoMessage: `Xcode version ${sysInfoData.xcodeVer} satisfies minimum required version ${Constants.XCODE_MIN_REQUIRED_VERSION}.`,
+						warningMessage: `Xcode version ${sysInfoData.xcodeVer} is lower than minimum required version ${Constants.XCODE_MIN_REQUIRED_VERSION}.`,
+						additionalInformation: "To build your application for iOS, update your Xcode.",
+						platforms: [Constants.IOS_PLATFORM_NAME]
+					})
+				);
+			}
 		}
 
 		return result;
@@ -208,7 +220,7 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 		};
 	}
 
-	private processValidationErrors(data: { warnings: NativeScriptDoctor.IWarning[], infoMessage: string, platforms: string[]}): NativeScriptDoctor.IInfo[] {
+	private processValidationErrors(data: { warnings: NativeScriptDoctor.IWarning[], infoMessage: string, platforms: string[] }): NativeScriptDoctor.IInfo[] {
 		if (data.warnings.length > 0) {
 			return data.warnings.map(warning => this.convertWarningToInfo(warning));
 		}

--- a/lib/local-build-requirements/ios-local-build-requirements.ts
+++ b/lib/local-build-requirements/ios-local-build-requirements.ts
@@ -1,4 +1,6 @@
 import { HostInfo } from "../host-info";
+import * as semver from "semver";
+import { Constants } from "../constants";
 
 export class IosLocalBuildRequirements {
 	constructor(private sysInfo: NativeScriptDoctor.ISysInfo,
@@ -6,11 +8,17 @@ export class IosLocalBuildRequirements {
 
 	public async checkRequirements(): Promise<boolean> {
 		if (!this.hostInfo.isDarwin ||
-			!await this.sysInfo.getXcodeVersion() ||
+			!await this.isXcodeVersionValid() ||
 			!await this.sysInfo.getXcodeprojLocation()) {
 			return false;
 		}
 
 		return true;
+	}
+
+	public async isXcodeVersionValid(): Promise<boolean> {
+		const xcodeVersion = await this.sysInfo.getXcodeVersion();
+
+		return !!xcodeVersion && (semver.major(semver.coerce(xcodeVersion)) >= Constants.XCODE_MIN_REQUIRED_VERSION);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/chai": "4.1.0",
     "@types/mocha": "2.2.32",
-    "@types/semver": "5.3.30",
+    "@types/semver": "5.5.0",
     "@types/temp": "0.8.29",
     "@types/winreg": "1.2.30",
     "chai": "4.1.2",
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "osenv": "0.1.3",
-    "semver": "5.3.0",
+    "semver": "5.5.1",
     "temp": "0.8.3",
     "unzip": "0.1.11",
     "winreg": "1.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/ios-local-build-requirements.ts
+++ b/test/ios-local-build-requirements.ts
@@ -1,0 +1,125 @@
+import { IosLocalBuildRequirements } from "../lib/local-build-requirements/ios-local-build-requirements";
+import { assert } from "chai";
+import { HostInfo } from "../lib/host-info";
+import { Constants } from "../lib/constants";
+
+interface ITestCaseData {
+	testName: string;
+	expectedResult: boolean;
+	getXcodeVersion?: string;
+	minRequiredXcodeVersion?: number;
+	getXcodeprojLocation?: string;
+	isDarwin?: boolean;
+}
+
+describe("iOSLocalBuildRequirements", () => {
+	const setupTestCase = (results: ITestCaseData): IosLocalBuildRequirements => {
+		const sysInfo: NativeScriptDoctor.ISysInfo = <any>{
+			getXcodeVersion: async (): Promise<string> => results.hasOwnProperty("getXcodeVersion") ? results.getXcodeVersion : "10.0",
+			getXcodeprojLocation: async (): Promise<string> => results.hasOwnProperty("getXcodeprojLocation") ? results.getXcodeprojLocation : "path to xcodeproj",
+		};
+
+		const hostInfo: HostInfo = <any>{
+			isDarwin: results.hasOwnProperty("isDarwin") ? results.isDarwin : true
+		};
+
+		const iOSLocalBuildRequirements = new IosLocalBuildRequirements(sysInfo, hostInfo);
+		return iOSLocalBuildRequirements;
+	};
+
+	describe("isXcodeVersionValid", () => {
+		const testCases: ITestCaseData[] = [
+			{
+				testName: "returns false when Xcode is not installed",
+				getXcodeVersion: null,
+				expectedResult: false
+			},
+			{
+				testName: "returns false when Xcode's major version is below min required version",
+				getXcodeVersion: "10.0",
+				minRequiredXcodeVersion: 11,
+				expectedResult: false
+			},
+			{
+				testName: "returns true when Xcode's major version equals min required version",
+				getXcodeVersion: "10.0",
+				minRequiredXcodeVersion: 10,
+				expectedResult: true
+			},
+			{
+				testName: "returns true when Xcode's major version equals min required version",
+				getXcodeVersion: "12.0",
+				minRequiredXcodeVersion: 10,
+				expectedResult: true
+			}
+		];
+
+		testCases.forEach(testCase => {
+			it(testCase.testName, async () => {
+				const iOSLocalBuildRequirements = setupTestCase(testCase);
+				let originalXcodeVersion = Constants.XCODE_MIN_REQUIRED_VERSION;
+				Constants.XCODE_MIN_REQUIRED_VERSION = testCase.minRequiredXcodeVersion || Constants.XCODE_MIN_REQUIRED_VERSION;
+
+				const isXcodeVersionValid = await iOSLocalBuildRequirements.isXcodeVersionValid();
+
+				// Get back the XCODE_MIN_REQUIRED_VERSION value.
+				Constants.XCODE_MIN_REQUIRED_VERSION = originalXcodeVersion;
+
+				assert.equal(isXcodeVersionValid, testCase.expectedResult);
+			});
+		});
+	});
+
+	describe("checkRequirements", () => {
+		const testCases: ITestCaseData[] = [
+			{
+				testName: "returns false when OS is not macOS",
+				isDarwin: false,
+				expectedResult: false
+			},
+			{
+				testName: "returns false when Xcode is not installed",
+				getXcodeVersion: null,
+				expectedResult: false
+			},
+			{
+				testName: "returns false when Xcode's major version is below min required version",
+				getXcodeVersion: "10.0",
+				minRequiredXcodeVersion: 11,
+				expectedResult: false
+			},
+			{
+				testName: "returns false when xcodeproj is not installed",
+				getXcodeprojLocation: null,
+				expectedResult: false
+			},
+			{
+				testName: "returns true when Xcode's major version equals min required version",
+				getXcodeVersion: "10.0",
+				minRequiredXcodeVersion: 10,
+				expectedResult: true
+			},
+			{
+				testName: "returns true when Xcode's major version equals min required version",
+				getXcodeVersion: "12.0",
+				minRequiredXcodeVersion: 10,
+				expectedResult: true
+			}
+		];
+
+		testCases.forEach(testCase => {
+			it(testCase.testName, async () => {
+				const iOSLocalBuildRequirements = setupTestCase(testCase);
+				let originalXcodeVersion = Constants.XCODE_MIN_REQUIRED_VERSION;
+				Constants.XCODE_MIN_REQUIRED_VERSION = testCase.minRequiredXcodeVersion || Constants.XCODE_MIN_REQUIRED_VERSION;
+
+				const isXcodeVersionValid = await iOSLocalBuildRequirements.checkRequirements();
+
+				// Get back the XCODE_MIN_REQUIRED_VERSION value.
+				Constants.XCODE_MIN_REQUIRED_VERSION = originalXcodeVersion;
+
+				assert.equal(isXcodeVersionValid, testCase.expectedResult);
+			});
+		});
+	});
+});


### PR DESCRIPTION
Currently iOS apps cannot be build with Xcode versions below 9, so add a check for the min supported Xcode version.