### PR TITLE
feat: set min required compile SDK to 28

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -22,7 +22,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 		"android-27",
 		"android-28",
 	];
-	private static MIN_REQUIRED_COMPILE_TARGET = 22;
+	private static MIN_REQUIRED_COMPILE_TARGET = 28;
 	private static REQUIRED_BUILD_TOOLS_RANGE_PREFIX = ">=23";
 	private static VERSION_REGEX = /((\d+\.){2}\d+)/;
 	private static MIN_JAVA_VERSION = "1.8.0";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",


### PR DESCRIPTION
As we are going to set min required Android Support Library to be 28 (in the modules), we need to set the min required compile SDK to 28 as well (as Android Support Library 28 relies on resources included in this version of the SDK and the project cannot be build without them). This way CLI will not allow building an application without installing the Android SDK 28 first.