### PR TITLE
fix: fix sporadic "EBADF: bad file descriptor, write" error

### DIFF
--- a/lib/wrappers/file-system.ts
+++ b/lib/wrappers/file-system.ts
@@ -37,7 +37,6 @@ export class FileSystem {
 								const outfile = fs.createWriteStream(filePath);
 								stream.once('end', () => {
 									zipFile.readEntry();
-									outfile.close();
 								});
 								stream.pipe(outfile);
 							});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",


### PR DESCRIPTION
Sometimes the out stream is closed before receiving stream's end event. In this case "EBADF: bad file descriptor, write" error is thrown