### PR TITLE
fix: prompts to install javac should not be shown on macOS

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,4 +16,5 @@ export class Constants {
 	public static VERSION_PROPERTY_NAME = "version";
 	public static XCODE_MIN_REQUIRED_VERSION = 9;
 	public static JAVAC_EXECUTABLE_NAME = "javac";
+	public static JAVA_EXECUTABLE_NAME = "java";
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,4 +15,5 @@ export class Constants {
 	public static ANDROID_RUNTIME = "tns-android";
 	public static VERSION_PROPERTY_NAME = "version";
 	public static XCODE_MIN_REQUIRED_VERSION = 9;
+	public static JAVAC_EXECUTABLE_NAME = "javac";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1016,12 +1016,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1036,17 +1038,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1163,7 +1168,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1175,6 +1181,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1189,6 +1196,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1196,12 +1204,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1220,6 +1230,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1300,7 +1311,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1312,6 +1324,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1433,6 +1446,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",
   "scripts": {
-    "test": "node_modules/.bin/istanbul cover node_modules/.bin/mocha -- --recursive"
+    "test": "node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive"
   },
   "repository": {
     "type": "git",

--- a/typings/interfaces.ts
+++ b/typings/interfaces.ts
@@ -318,6 +318,11 @@ declare module NativeScriptDoctor {
 		 */
 		javacVersion: string;
 		/**
+		 * java version string as returned by `java -version`.
+		 * @type {string}
+		 */
+		javaVersion: string;
+		/**
 		 * true if the Android SDK Tools are installed and configured correctly.
 		 * @type {boolean}
 		 */


### PR DESCRIPTION
### fix: prompts to install javac should not be shown on macOS  …

macOS has handle when you try to execute java or javac to prompt to install it. However, we do not want to bother the user with such prompts. Currently we are executing `javac -version` to determine the version. Instead of this, check if there's `javac` in the PATH before executing the command. In case there's no javac in the path, do not execute `javac -version`, so we'll not prompt the user to install it.

### feat: expose methods for getting JAVA version
Expose methods for getting JAVA version from PATH, from JAVA_HOME and wrapper for both of them. This is required for some verifications around avdmanager executable