### PR TITLE
fix: javac detection does not work as required by Gradle

### DIFF
--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -61,7 +61,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 
 	public getJavaCompilerVersion(): Promise<string> {
 		return this.getValueForProperty(() => this.javaCompilerVerCache, async (): Promise<string> => {
-			const javacVersion = (await this.getVersionOfJavaExecutableFromJavaHome(Constants.JAVAC_EXECUTABLE_NAME, SysInfo.JAVA_COMPILER_VERSION_REGEXP)) ||
+			const javacVersion = process.env["JAVA_HOME"] ? (await this.getVersionOfJavaExecutableFromJavaHome(Constants.JAVAC_EXECUTABLE_NAME, SysInfo.JAVA_COMPILER_VERSION_REGEXP)) :
 				(await this.getVersionOfJavaExecutableFromPath(Constants.JAVAC_EXECUTABLE_NAME, SysInfo.JAVA_COMPILER_VERSION_REGEXP));
 
 			return javacVersion;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/sys-info.ts
+++ b/test/sys-info.ts
@@ -241,6 +241,31 @@ describe("SysInfo unit tests", () => {
 			assert.deepEqual(execCommands, ['which javac', '"javac" -version']);
 		});
 
+		it("null when there is incorrect JAVA_HOME on non-Windows OS", async () => {
+			const originalJavaHome = process.env[JavaHomeName];
+			process.env[JavaHomeName] = "/some/invalid/dir/name/where/java/does/not/exist";
+
+			const result = await sysInfo.getJavaCompilerVersion();
+
+			process.env[JavaHomeName] = originalJavaHome;
+
+			assert.deepEqual(result, null);
+			assert.deepEqual(execCommands, []);
+		});
+
+		it("null when there is incorrect JAVA_HOME on Window OS", async () => {
+			const originalJavaHome = process.env[JavaHomeName];
+			hostInfo.isWindows = true;
+			process.env[JavaHomeName] = "C:\\Program Files\\Not existing dir";
+
+			const result = await sysInfo.getJavaCompilerVersion();
+
+			process.env[JavaHomeName] = originalJavaHome;
+
+			assert.deepEqual(result, null);
+			assert.deepEqual(execCommands, []);
+		});
+
 		it("java compiler version when there is no JAVA_HOME on Window OS", async () => {
 			const originalJavaHome = process.env[JavaHomeName];
 			hostInfo.isWindows = true;


### PR DESCRIPTION
The current `javac` detection tries to get the `javac` path from JAVA_HOME and to verify it is correct. In case it fails somewhere, it fallbacks to check the `javac` from PATH. So, from users' perspective it seems javac is setup correctly.
However, Gradle works in slightly different manner - it checks if you have JAVA_HOME and if so - verifies `java` from it. In case there's no `java` in the `$JAVA_HOME/bin/java`, an error is thrown.
Make our check for `javac` in the same way - in case you have set JAVA_HOME, we'll verify `javac` from there. This is exactly the same as the one we had prior 1.9.0 version, so this is just a regression fix.
Add unit tests to cover this scenario.