### PR TITLE
feat: set min required Xcode version to 10

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,7 +14,7 @@ export class Constants {
 	public static NATIVESCRIPT_KEY = "nativescript";
 	public static ANDROID_RUNTIME = "tns-android";
 	public static VERSION_PROPERTY_NAME = "version";
-	public static XCODE_MIN_REQUIRED_VERSION = 9;
+	public static XCODE_MIN_REQUIRED_VERSION = 10;
 	public static JAVAC_EXECUTABLE_NAME = "javac";
 	public static JAVA_EXECUTABLE_NAME = "java";
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",


### PR DESCRIPTION
With NativeScript 6.0.0 release we will require Xcode 10 as min supported.