### PR TITLE
fix: Java 13 is not supported, but it is not detected as such

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -39,6 +39,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 	private static REQUIRED_BUILD_TOOLS_RANGE_PREFIX = ">=23";
 	private static VERSION_REGEX = /((\d+\.){2}\d+)/;
 	private static MIN_JAVA_VERSION = "1.8.0";
+	private static MAX_JAVA_VERSION = "13.0.0";
 
 	private toolsInfo: NativeScriptDoctor.IAndroidToolsInfoData;
 	public get androidHome(): string {
@@ -120,8 +121,8 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 				"^10.0.0": "4.1.0-2018.5.18.1"
 			};
 
-			if (semver.lt(installedJavaCompilerSemverVersion, AndroidToolsInfo.MIN_JAVA_VERSION)) {
-				warning = `Javac version ${installedJavaCompilerVersion} is not supported. You have to install at least ${AndroidToolsInfo.MIN_JAVA_VERSION}.`;
+			if (semver.lt(installedJavaCompilerSemverVersion, AndroidToolsInfo.MIN_JAVA_VERSION) || semver.gte(installedJavaCompilerSemverVersion, AndroidToolsInfo.MAX_JAVA_VERSION)) {
+				warning = `Javac version ${installedJavaCompilerVersion} is not supported. You have to install at least ${AndroidToolsInfo.MIN_JAVA_VERSION} and below ${AndroidToolsInfo.MAX_JAVA_VERSION}.`;
 			} else {
 				runtimeVersion = this.getRuntimeVersion({runtimeVersion, projectDir});
 				if (runtimeVersion) {

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -275,11 +275,15 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 				try {
 					const spawnResult = await this.childProcess.spawnFromEvent("pod", ["install"], "exit", { spawnOptions: { cwd: xcodeProjectDir } });
 					if (spawnResult.exitCode) {
+						this.fileSystem.deleteEntry(tempDirectory);
 						return false;
 					} else {
-						return this.fileSystem.exists(path.join(xcodeProjectDir, "cocoapods.xcworkspace"));
+						const exists = this.fileSystem.exists(path.join(xcodeProjectDir, "cocoapods.xcworkspace"));
+						this.fileSystem.deleteEntry(tempDirectory);
+						return exists;
 					}
 				} catch (err) {
+					this.fileSystem.deleteEntry(tempDirectory);
 					return null;
 				}
 			} else {

--- a/lib/wrappers/file-system.ts
+++ b/lib/wrappers/file-system.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as yauzl from "yauzl";
 import * as util from "util";
+import * as shelljs from "shelljs";
 
 const access = util.promisify(fs.access);
 const mkdir = util.promisify(fs.mkdir);
@@ -57,6 +58,10 @@ export class FileSystem {
 	public readJson<T>(filePath: string, options?: { encoding?: null; flag?: string; }): T {
 		const content = fs.readFileSync(filePath, options);
 		return JSON.parse(content.toString());
+	}
+
+	public deleteEntry(filePath: string): void {
+		shelljs.rm("-rf", filePath);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/mocha": "2.2.32",
     "@types/rimraf": "2.0.2",
     "@types/semver": "5.5.0",
+    "@types/shelljs": "0.8.6",
     "@types/temp": "0.8.29",
     "@types/winreg": "1.2.30",
     "@types/yauzl": "2.9.0",
@@ -49,6 +50,7 @@
     "lodash": "4.17.15",
     "osenv": "0.1.3",
     "semver": "5.5.1",
+    "shelljs": "0.7.6",
     "temp": "0.8.3",
     "winreg": "1.2.2",
     "yauzl": "2.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-doctor",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "lib/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/test/android-tools-info.ts
+++ b/test/android-tools-info.ts
@@ -97,11 +97,19 @@ describe("androidToolsInfo", () => {
 			},
 			{
 				javacVersion: "1.7.0",
-				warnings: ["Javac version 1.7.0 is not supported. You have to install at least 1.8.0."]
+				warnings: ["Javac version 1.7.0 is not supported. You have to install at least 1.8.0 and below 13.0.0."]
 			},
 			{
 				javacVersion: "1.7.0_132",
-				warnings: ["Javac version 1.7.0_132 is not supported. You have to install at least 1.8.0."]
+				warnings: ["Javac version 1.7.0_132 is not supported. You have to install at least 1.8.0 and below 13.0.0."]
+			},
+			{
+				javacVersion: "13.0.0",
+				warnings: ["Javac version 13.0.0 is not supported. You have to install at least 1.8.0 and below 13.0.0."]
+			},
+			{
+				javacVersion: "14.1.0",
+				warnings: ["Javac version 14.1.0 is not supported. You have to install at least 1.8.0 and below 13.0.0."]
 			},
 			{
 				javacVersion: null,


### PR DESCRIPTION
#### fix: Java 13 is not supported, but it is not detected as such

Currently Java 13 is not supported, but if you have it installed, `nativescript-doctor` decides it is okay and allows you to build. At that point you receive non-descriptive error message. Fix the case by forbidding Java 13 and above until we support it.

#### fix: ensure temp files are deleted
Ensure the temp files created by nativescript-doctor are deleted
