### PR TITLE
Resolve paths before testing for existence

### DIFF
--- a/lib/wrappers/file-system.ts
+++ b/lib/wrappers/file-system.ts
@@ -9,7 +9,7 @@ const mkdir = util.promisify(fs.mkdir);
 
 export class FileSystem {
 	public exists(filePath: string): boolean {
-		return fs.existsSync(filePath);
+		return fs.existsSync(path.resolve(filePath));
 	}
 
 	public extractZip(pathToZip: string, outputDir: string): Promise<void> {


### PR DESCRIPTION
Issue:
Environment aliases are not resolved by `fs.exists` but environment variables are.

Example:
`export ANDROID_HOME=~/Library/Android/sdk` will fail
`export ANDROID_HOME=$HOME/Library/Android/sdk` will pass

Fix:
Resolve the path before testing it by wrapping it with `path.resolve()`.

Related Issue:
https://github.com/NativeScript/nativescript-cli/issues/1097