### PR TITLE
Handle file paths correctly on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '8'
+- '14'
 git:
   submodules: false
 before_script:

--- a/lib/wrappers/file-system.ts
+++ b/lib/wrappers/file-system.ts
@@ -1,11 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as yauzl from "yauzl";
-import * as util from "util";
 import * as shelljs from "shelljs";
-
-const access = util.promisify(fs.access);
-const mkdir = util.promisify(fs.mkdir);
 
 export class FileSystem {
 	public exists(filePath: string): boolean {
@@ -66,12 +62,5 @@ export class FileSystem {
 }
 
 function createParentDirsIfNeeded(filePath: string) {
-	const dirs = path.dirname(filePath).split(path.sep);
-	return dirs.reduce((p, dir) => p.then(parent => {
-		const current = `${parent}${path.sep}${dir}`;
-
-		return access(current)
-			.catch(e => mkdir(current))
-			.then(() => current);
-	}), Promise.resolve(''));
+	return fs.promises.mkdir(path.dirname(filePath), {recursive: true});
 }

--- a/test/wrappers/file-system.ts
+++ b/test/wrappers/file-system.ts
@@ -18,7 +18,7 @@ describe('FileSystem', () => {
 		].join('');
 		const tmpDir = `${tmpdir()}/${datetime}`;
 		const testFilePath = `${__dirname}/example.zip`;
-		const filesThatNeedToExtsit = [
+		const filesThatNeedToExist = [
 			`${tmpDir}/test/android-local-build-requirements.ts`,
 			`${tmpDir}/test/android-tools-info.ts`,
 			`${tmpDir}/test/ios-local-build-requirements.ts`,
@@ -27,11 +27,11 @@ describe('FileSystem', () => {
 		];
 
 		it('should extract in example zip archive in tmp folder', done => {
-			const fs  = new FileSystem();
+			const fs = new FileSystem();
 
 			fs.extractZip(testFilePath, tmpDir)
 				.then(() => {
-					const allExists = filesThatNeedToExtsit
+					const allExists = filesThatNeedToExist
 						.map(fs.exists)
 						.reduce((acc, r) => acc && r, true);
 


### PR DESCRIPTION
Had to fix this to prevent this error when running tests on Windows

```
Error: EINVAL: invalid argument, mkdir 'C:\C:'
```